### PR TITLE
Chore: don't send queries without a queryType

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { GithubDataSourceOptions, Label, GitHubQuery, GitHubVariableQuery } from './types';
-import { ReplaceVariables } from './variables';
+import { replaceVariables } from './variables';
 import { isValid } from './validation';
 import { getAnnotationsFromFrame } from 'common/annotationsFromDataFrame';
 
@@ -21,8 +21,13 @@ export class DataSource extends DataSourceWithBackend<GitHubQuery, GithubDataSou
 
   templateSrv = getTemplateSrv();
 
+  // Only execute queries that have a query type
+  filterQuery = (query: GitHubQuery) => {
+    return !!query.queryType;
+  };
+
   applyTemplateVariables(query: GitHubQuery, _: ScopedVars): Record<string, any> {
-    return ReplaceVariables(this.templateSrv, query);
+    return replaceVariables(this.templateSrv, query);
   }
 
   async getLabels(repository: string, owner: string, query?: string): Promise<Label[]> {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,14 +1,14 @@
 import { GitHubQuery } from './types';
 import { TemplateSrv } from '@grafana/runtime';
 
-export const ReplaceVariable = (t: TemplateSrv, value?: string): string | undefined => {
+export const replaceVariable = (t: TemplateSrv, value?: string): string | undefined => {
   return !!value ? t.replace(value) : value;
 };
 
-export const ReplaceVariables = (t: TemplateSrv, query: GitHubQuery): GitHubQuery => {
+export const replaceVariables = (t: TemplateSrv, query: GitHubQuery): GitHubQuery => {
   Object.keys(query).forEach(key => {
     if (typeof query[key] === 'string') {
-      query[key] = ReplaceVariable(t, query[key]);
+      query[key] = replaceVariable(t, query[key]);
     }
   });
 
@@ -16,7 +16,7 @@ export const ReplaceVariables = (t: TemplateSrv, query: GitHubQuery): GitHubQuer
     const { options } = query;
     Object.keys(options).forEach(key => {
       if (typeof options[key] === 'string') {
-        options[key] = ReplaceVariable(t, options[key]);
+        options[key] = replaceVariable(t, options[key]);
       }
     });
     query.options = options;


### PR DESCRIPTION
This PR will avoid sending a bad query when you first add it


It also changes upper case `ReplaceVariables` to lower case `replaceVariables` -- in typescript, we use lowercase for functions and uppercase for classes and components 