### PR TITLE
feat: Allow no pull request time field

### DIFF
--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -167,10 +167,10 @@ func GetAllPullRequests(ctx context.Context, client Client, opts models.ListPull
 
 // GetPullRequestsInRange uses the graphql search endpoint API to find pull requests in the given time range.
 func GetPullRequestsInRange(ctx context.Context, client Client, opts models.ListPullRequestsOptions, from time.Time, to time.Time) (PullRequests, error) {
-	search := []string{
-		fmt.Sprintf("%s:%s..%s", opts.TimeField.String(), from.Format(time.RFC3339), to.Format(time.RFC3339)),
+	search := []string{}
+	if opts.TimeField != models.PullRequestNone {
+		search = []string{fmt.Sprintf("%s:%s..%s", opts.TimeField.String(), from.Format(time.RFC3339), to.Format(time.RFC3339))}
 	}
-
 	if opts.Query != nil {
 		search = append(search, *opts.Query)
 	}

--- a/pkg/models/pull_requests.go
+++ b/pkg/models/pull_requests.go
@@ -10,6 +10,8 @@ const (
 	PullRequestCreatedAt
 	// PullRequestMergedAt is used when filtering when a Pull Request was merged
 	PullRequestMergedAt
+	// PullRequestNone is used when the results are not filtered by time. Without any other filters, using this could easily cause an access token to be rate limited
+	PullRequestNone
 )
 
 func (d PullRequestTimeField) String() string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export enum PullRequestTimeField {
   ClosedAt,
   CreatedAt,
   MergedAt,
+  None,
 }
 
 export enum IssueTimeField {

--- a/src/views/QueryEditorPullRequests.tsx
+++ b/src/views/QueryEditorPullRequests.tsx
@@ -48,7 +48,7 @@ export default (props: Props) => {
       <QueryInlineField
         labelWidth={LeftColumnWidth}
         label="Time Field"
-        tooltip="The time field to filter on th time range"
+        tooltip="The time field to filter on the time range. WARNING: If selecting 'None', be mindful of the amount of data being queried. On larger repositories, querying all pull requests could easily cause rate limiting"
       >
         <Select
           width={RightColumnWidth}


### PR DESCRIPTION
This will allow users to create panels like a single stat that shows all active pull requests, regardless of when they were created.

* fixes #57 