### PR TITLE
Fix Query type dropdown label

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - '3090:3000'
     volumes:
-      - ./:/var/lib/grafana/plugins/grafana-github-datasoure
+      - ./:/var/lib/grafana/plugins/grafana-github-datasource
       - grafana-storage:/var/lib/grafana
       # - ./provisioning:/etc/grafana/provisioning
     environment:
@@ -14,5 +14,6 @@ services:
       - GF_LOG_LEVEL=debug
       - GF_DATAPROXY_LOGGING=true
       - GF_FEATURE_TOGGLES_ENABLE=expressions inspect transformations newEdit
+      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-github-datasource
 volumes:
   grafana-storage:

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -75,7 +75,7 @@ const queryEditors: {
 
 const queryTypeOptions: Array<SelectableValue<string>> = Object.keys(QueryType).map(v => {
   return {
-    label: v.replace('/_/gi', ' '),
+    label: v.replace(/_/gi, ' '),
     value: v,
   };
 });


### PR DESCRIPTION
- FIx the query type dropdown label by removing `''` from the regex
- Fix typo on docker-compose volumes list
- Add `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS` to make it easier to install the dev plugin while using docker-compose (see https://github.com/grafana/grafana/issues/24027)

@kminehart do you think we could use some guidelines for contributing? I am thinking on something like "how to contribute" with steps like the `yarn dev/install` and `docker-compose` for starters.