### PR TITLE
Rename user:read to read:user to match GitHub UI

### DIFF
--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -51,7 +51,7 @@ export class ConfigEditor extends PureComponent<ConfigEditorProps> {
               <li>read:packages</li>
             </ul>
             <ul>
-              <li>user:read</li>
+              <li>read:user</li>
               <li>user:email</li>
             </ul>
           </pre>


### PR DESCRIPTION
When creating a token https://github.com/settings/tokens/new this permission is named differently