### PR TITLE
Fix case where object property cannot be assigned

### DIFF
--- a/src/variables.ts
+++ b/src/variables.ts
@@ -9,15 +9,15 @@ export const replaceVariable = (t: TemplateSrv, value?: string, scoped: ScopedVa
 export const replaceVariables = (t: TemplateSrv, query: GitHubQuery, scoped: ScopedVars): GitHubQuery => {
   Object.keys(query).forEach((key) => {
     if (typeof query[key] === 'string') {
-      query[key] = replaceVariable(t, query[key], scoped);
+      query = { ...query, [key]: replaceVariable(t, query[key], scoped) };
     }
   });
 
   if (query.options) {
-    const { options } = query;
+    let { options } = query;
     Object.keys(options).forEach((key) => {
       if (typeof options[key] === 'string') {
-        options[key] = replaceVariable(t, options[key], scoped);
+        options = {...options, [key]: replaceVariable(t, options[key], scoped)}
       }
     });
     query.options = options;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -17,7 +17,7 @@ export const replaceVariables = (t: TemplateSrv, query: GitHubQuery, scoped: Sco
     let { options } = query;
     Object.keys(options).forEach((key) => {
       if (typeof options[key] === 'string') {
-        options = {...options, [key]: replaceVariable(t, options[key], scoped)}
+        options = { ...options, [key]: replaceVariable(t, options[key], scoped) };
       }
     });
     query.options = options;


### PR DESCRIPTION
This PR fixes https://github.com/grafana/support-escalations/issues/1786 . 

Client has reported an error where the query options cannot be assigned correctly. This fix solves this case and allows query options to be updated in said cases.