### PR TITLE
Correctly calculate how long a merged PR was open for

### DIFF
--- a/pkg/github/pull_requests.go
+++ b/pkg/github/pull_requests.go
@@ -110,7 +110,7 @@ func (p PullRequests) Frames() data.Frames {
 		}
 
 		if mergedAt != nil {
-			secondsOpen = v.ClosedAt.UTC().Sub(v.MergedAt.UTC()).Seconds()
+			secondsOpen = v.MergedAt.UTC().Sub(v.CreatedAt.UTC()).Seconds()
 		}
 
 		frame.AppendRow(


### PR DESCRIPTION
I believe this fixes #145 by calculating `open_time` on merged PRs as `merged_at` - `created_at`, which makes a lot more sense than the 0s/1s it currently contains :)