### PR TITLE
Add vulnerabilities to the Github Datasource

### DIFF
--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -116,6 +116,17 @@ func (d *Datasource) HandlePackagesQuery(ctx context.Context, query *models.Pack
 	return GetAllPackages(ctx, d.client, opt)
 }
 
+// HandleVulnerabilitiesQuery is the query handler for listing GitHub Packages
+func (d *Datasource) HandleVulnerabilitiesQuery(ctx context.Context, query *models.VulnerabilityQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.ListVulnerabilitiesOptions{
+		Repository: query.Repository,
+		Owner:      query.Owner,
+		Query:      query.Options.Query,
+	}
+
+	return GetAllVulnerabilities(ctx, d.client, opt)
+}
+
 // CheckHealth calls frequently used endpoints to determine if the client has sufficient privileges
 func (d *Datasource) CheckHealth(ctx context.Context) error {
 	_, err := GetAllRepositories(ctx, d.client, models.ListRepositoriesOptions{

--- a/pkg/github/vulnerabilities.go
+++ b/pkg/github/vulnerabilities.go
@@ -10,7 +10,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-// QueryListLabels lists all labels in a repository
+// QueryListVulnerabilities lists all labels in a repository
 // {
 //   repository(name: "grafana", owner: "grafana") {
 //     labels(first: 100) {
@@ -41,7 +41,6 @@ import (
 //         }
 //     }
 // }
-
 type QueryListVulnerabilities struct {
 	Repository struct {
 		VulnerabilityAlerts struct {
@@ -51,6 +50,7 @@ type QueryListVulnerabilities struct {
 	} `graphql:"repository(name: $name, owner: $owner)"`
 }
 
+// Vulnerability is used to collect Vulnerability information about GitHub
 type Vulnerability struct {
 	CreatedAt             githubv4.DateTime
 	DismissedAt           githubv4.DateTime
@@ -58,6 +58,7 @@ type Vulnerability struct {
 	SecurityVulnerability securityVulnerability
 }
 
+// securityVulnerability has all the security information
 type securityVulnerability struct {
 	Package                SecurityAdvisoryPackage
 	Advisory               SecurityAdvisory
@@ -65,10 +66,12 @@ type securityVulnerability struct {
 	VulnerableVersionRange string
 }
 
+// SecurityAdvisoryPackageVersion is a struct with an idenifyier to identify the package
 type SecurityAdvisoryPackageVersion struct {
 	Identifier string
 }
 
+// SecurityAdvisory is the main security report for a vulnerability in a repository
 type SecurityAdvisory struct {
 	Description string
 	Cvss        CVSS
@@ -77,19 +80,21 @@ type SecurityAdvisory struct {
 	WithdrawnAt githubv4.DateTime
 }
 
+// CVSS is a way of grading the severity of a vulnerability
 type CVSS struct {
 	Score        float64
 	VectorString string
 }
 
+// SecurityAdvisoryPackage is an object to share the name of the package that is impacted
 type SecurityAdvisoryPackage struct {
 	Name string
 }
 
-// Labels is a list of GitHub labels
+// Vulnerabilities is a list of GitHub vulnerabilities
 type Vulnerabilities []Vulnerability
 
-// Frames converts the list of labels to a Grafana DataFrame
+// Frames converts the list of vulnerabilities to a Grafana DataFrame
 func (a Vulnerabilities) Frames() data.Frames {
 	frame := data.NewFrame(
 		"vulnerabilities",

--- a/pkg/github/vulnerabilities.go
+++ b/pkg/github/vulnerabilities.go
@@ -22,7 +22,6 @@ import (
 //     }
 //   }
 // }
-
 // {
 //     repository(name: "repo-name", owner: "repo-owner") {
 //         vulnerabilityAlerts(first: 100) {

--- a/pkg/github/vulnerabilities.go
+++ b/pkg/github/vulnerabilities.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"context"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// QueryListLabels lists all labels in a repository
+// {
+//   repository(name: "grafana", owner: "grafana") {
+//     labels(first: 100) {
+//       nodes {
+//         color
+//         description
+//         name
+//       }
+//     }
+//   }
+// }
+type QueryListVulnerabilities struct {
+	Repository struct {
+		Vulnerabilities struct {
+			Nodes    Vulnerabilities
+			PageInfo PageInfo
+		} `graphql:"xxx(first: 100, after: $cursor, query: $query)"`
+	} `graphql:"repository(name: $name, owner: $owner)"`
+}
+
+// Label is a GitHub label used in Issues / Pull Requests
+type Vulnerability struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Labels is a list of GitHub labels
+type Vulnerabilities []Vulnerability
+
+// Frames converts the list of labels to a Grafana DataFrame
+func (a Vulnerabilities) Frames() data.Frames {
+	frame := data.NewFrame(
+		"vulnerabilities",
+		data.NewField("name", nil, []string{}),
+		data.NewField("description", nil, []string{}),
+	)
+
+	for _, v := range a {
+		frame.AppendRow(
+			v.Name,
+			v.Description,
+		)
+	}
+
+	return data.Frames{frame}
+}
+
+// GetAllVulnerabilities gets all vulnerabilities from a GitHub repository
+func GetAllVulnerabilities(ctx context.Context, client Client, opts models.ListVulnerabilitiesOptions) (Vulnerabilities, error) {
+	// var (
+	// 	variables = map[string]interface{}{
+	// 		"cursor": (*githubv4.String)(nil),
+	// 		"query":  githubv4.String(opts.Query),
+	// 		"owner":  githubv4.String(opts.Owner),
+	// 		"name":   githubv4.String(opts.Repository),
+	// 	}
+
+	// 	vuln = Vulnerabilities{}
+	// )
+
+	// for {
+	// 	q := &QueryListVulnerabilities{}
+	// 	if err := client.Query(ctx, q, variables); err != nil {
+	// 		return nil, errors.WithStack(err)
+	// 	}
+
+	// 	vuln = append(vuln, q.Repository.Vulnerabilities.Nodes...)
+
+	// 	if !q.Repository.Vulnerabilities.PageInfo.HasNextPage {
+	// 		break
+	// 	}
+	// 	variables["cursor"] = q.Repository.Vulnerabilities.PageInfo.EndCursor
+	// }
+
+	temp := []Vulnerability{}
+	v := Vulnerability{
+		Name:        "test",
+		Description: "description",
+	}
+
+	temp = append(temp, v)
+
+	return temp, nil
+}

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -25,6 +25,8 @@ const (
 	QueryTypePackages = "Packages"
 	// QueryTypeMilestones is used when querying for milestones in a repository
 	QueryTypeMilestones = "Milestones"
+	//
+	QueryTypeVulnerabilities = "Vulnerabilities"
 )
 
 // Query refers to the structure of a query built using the QueryEditor.
@@ -91,6 +93,11 @@ type PackagesQuery struct {
 
 // MilestonesQuery is used when querying for GitHub milestones
 type MilestonesQuery struct {
+	Query
+	Options ListMilestonesOptions `json:"options"`
+}
+
+type VulnerabilityQuery struct {
 	Query
 	Options ListMilestonesOptions `json:"options"`
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -25,7 +25,7 @@ const (
 	QueryTypePackages = "Packages"
 	// QueryTypeMilestones is used when querying for milestones in a repository
 	QueryTypeMilestones = "Milestones"
-	//
+	// QueryTypeVulnerabilities is used when querying a vulnerability for a repository
 	QueryTypeVulnerabilities = "Vulnerabilities"
 )
 
@@ -97,6 +97,7 @@ type MilestonesQuery struct {
 	Options ListMilestonesOptions `json:"options"`
 }
 
+// VulnerabilityQuery is used when querying for GitHub Repository Vulnerabilities
 type VulnerabilityQuery struct {
 	Query
 	Options ListMilestonesOptions `json:"options"`

--- a/pkg/models/vulnerabilities.go
+++ b/pkg/models/vulnerabilities.go
@@ -1,0 +1,13 @@
+package models
+
+// ListLabelsOptions is provided when listing Labels in a repository
+type ListVulnerabilitiesOptions struct {
+	// Repository is the name of the repository being queried (ex: grafana)
+	Repository string `json:"repository"`
+
+	// Owner is the owner of the repository (ex: grafana)
+	Owner string `json:"owner"`
+
+	// Query searches x by name and description
+	Query string `json:"query"`
+}

--- a/pkg/models/vulnerabilities.go
+++ b/pkg/models/vulnerabilities.go
@@ -1,6 +1,6 @@
 package models
 
-// ListLabelsOptions is provided when listing Labels in a repository
+// ListVulnerabilitiesOptions is provided when listing volnerabilities in a repository
 type ListVulnerabilitiesOptions struct {
 	// Repository is the name of the repository being queried (ex: grafana)
 	Repository string `json:"repository"`

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -20,6 +20,7 @@ type Datasource interface {
 	HandleLabelsQuery(context.Context, *models.LabelsQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandlePackagesQuery(context.Context, *models.PackagesQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleMilestonesQuery(context.Context, *models.MilestonesQuery, backend.DataQuery) (dfutil.Framer, error)
+	HandleVulnerabilitiesQuery(context.Context, *models.VulnerabilityQuery, backend.DataQuery) (dfutil.Framer, error)
 	CheckHealth(context.Context) error
 }
 
@@ -41,7 +42,7 @@ func CheckHealth(ctx context.Context, d Datasource, req *backend.CheckHealthRequ
 		}, nil
 	}
 	return &backend.CheckHealthResult{
-		Status: backend.HealthStatusOk,
+		Status:  backend.HealthStatusOk,
 		Message: backend.HealthStatusOk.String(),
 	}, nil
 }

--- a/pkg/plugin/datasource_caching.go
+++ b/pkg/plugin/datasource_caching.go
@@ -176,6 +176,16 @@ func (c *CachedDatasource) HandleMilestonesQuery(ctx context.Context, q *models.
 	return c.saveCache(req, f, err)
 }
 
+// HandleVulnerabilitiesQuery is the cache wrapper for the issue query handler
+func (c *CachedDatasource) HandleVulnerabilitiesQuery(ctx context.Context, q *models.VulnerabilityQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	if value, err := c.getCache(req); err == nil {
+		return value, err
+	}
+
+	f, err := c.datasource.HandleVulnerabilitiesQuery(ctx, q, req)
+	return c.saveCache(req, f, err)
+}
+
 // CheckHealth forwards the request to the datasource and does not perform any caching
 func (c *CachedDatasource) CheckHealth(ctx context.Context) error {
 	return c.datasource.CheckHealth(ctx)

--- a/pkg/plugin/instance.go
+++ b/pkg/plugin/instance.go
@@ -66,6 +66,11 @@ func (i *Instance) HandleMilestonesQuery(ctx context.Context, q *models.Mileston
 	return i.Datasource.HandleMilestonesQuery(ctx, q, req)
 }
 
+// HandleVulnerabilitiesQuery ...
+func (i *Instance) HandleVulnerabilitiesQuery(ctx context.Context, q *models.VulnerabilityQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	return i.Datasource.HandleVulnerabilitiesQuery(ctx, q, req)
+}
+
 // CheckHealth ...
 func (i *Instance) CheckHealth(ctx context.Context) error {
 	return i.Datasource.CheckHealth(ctx)

--- a/pkg/plugin/query_vulnerabilites.go
+++ b/pkg/plugin/query_vulnerabilites.go
@@ -16,7 +16,7 @@ func (s *Server) handleVulnerabilitesQuery(ctx context.Context, q backend.DataQu
 	return dfutil.FrameResponseWithError(s.Datasource.HandleVulnerabilitiesQuery(ctx, query, q))
 }
 
-// HandlePackages handles the plugin query for github Packages
+// HandleVulnerabilitites handles the plugin query for github Vulnerabilitites
 func (s *Server) HandleVulnerabilitites(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	return &backend.QueryDataResponse{
 		Responses: processQueries(ctx, req, s.handleVulnerabilitesQuery),

--- a/pkg/plugin/query_vulnerabilites.go
+++ b/pkg/plugin/query_vulnerabilites.go
@@ -1,0 +1,24 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/grafana/github-datasource/pkg/dfutil"
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func (s *Server) handleVulnerabilitesQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+	query := &models.VulnerabilityQuery{}
+	if err := UnmarshalQuery(q.JSON, query); err != nil {
+		return *err
+	}
+	return dfutil.FrameResponseWithError(s.Datasource.HandleVulnerabilitiesQuery(ctx, query, q))
+}
+
+// HandlePackages handles the plugin query for github Packages
+func (s *Server) HandleVulnerabilitites(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return &backend.QueryDataResponse{
+		Responses: processQueries(ctx, req, s.handleVulnerabilitesQuery),
+	}, nil
+}

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -52,6 +52,7 @@ func GetQueryHandlers(s *Server) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypePackages, s.HandlePackages)
 	mux.HandleFunc(models.QueryTypeMilestones, s.HandleMilestones)
 	mux.HandleFunc(models.QueryTypeRepositories, s.HandleRepositories)
+	mux.HandleFunc(models.QueryTypeVulnerabilities, s.HandleVulnerabilitites)
 
 	return mux
 }

--- a/src/dashboards/dashboard.json
+++ b/src/dashboards/dashboard.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_GITHUB",
+      "label": "GitHub",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-github-datasource",
+      "pluginName": "GitHub"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.5.0"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-github-datasource",
+      "name": "GitHub",
+      "version": "1.0.8"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -94,13 +131,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-<<<<<<< HEAD
   "id": null,
   "iteration": 1654462304304,
-=======
-  "id": 1,
-  "iteration": 1639085936786,
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
   "links": [],
   "liveNow": false,
   "panels": [
@@ -108,11 +140,7 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
-<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
-=======
-        "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -170,11 +198,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.3.1",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -244,11 +268,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.3.1",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "owner": "$organization",
@@ -315,11 +335,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "owner": "$organization",
@@ -345,11 +361,7 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
-<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
-=======
-        "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -403,11 +415,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -482,11 +490,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -558,11 +562,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -645,11 +645,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -689,11 +685,7 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
-<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
-=======
-        "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -751,11 +743,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -829,11 +817,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -904,11 +888,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -995,11 +975,7 @@
         "text": {},
         "textMode": "auto"
       },
-<<<<<<< HEAD
       "pluginVersion": "8.5.0",
-=======
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -1026,27 +1002,23 @@
     },
     {
       "collapsed": false,
-<<<<<<< HEAD
       "datasource": {
         "type": "grafana-github-datasource",
         "uid": "${DS_GITHUB}"
       },
-=======
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 15
       },
-      "id": 39,
+      "id": 37,
       "panels": [],
-      "title": "Security",
+      "title": "Data",
       "type": "row"
     },
     {
       "datasource": {
-<<<<<<< HEAD
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1055,53 +1027,57 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
-        "type": "grafana-github-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "links": [],
           "mappings": [],
-          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "green",
                 "value": null
               },
               {
-                "color": "yellow",
-                "value": 3
-              },
-              {
-                "color": "orange",
-                "value": 5
-              },
-              {
-                "color": "dark-red",
-                "value": 9
+                "color": "red",
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 74
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "author"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 136
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 14,
+        "h": 9,
+        "w": 12,
         "x": 0,
         "y": 16
       },
-      "id": 41,
+      "id": 2,
       "options": {
-<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1113,35 +1089,17 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
-=======
-        "displayMode": "lcd",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "/^cvssScore$/",
-          "values": true
-        },
-        "showUnfilled": true
-      },
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-github-datasource",
-            "uid": "${datasource}"
+          "options": {
+            "gitRef": "$branch"
           },
-          "format": 0,
-          "hide": true,
-          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Vulnerabilities",
+          "queryType": "Commits",
           "refId": "A",
-          "repository": "$repository",
-          "severity": 3
+          "repository": "$repository"
         }
       ],
-<<<<<<< HEAD
       "title": "Commits",
       "type": "table"
     },
@@ -1156,107 +1114,44 @@
             "filterable": false,
             "inspect": false
           },
-=======
-      "title": "Vulnerability CVSS Scores for $repository",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "advisoryDescription": true,
-              "cvssVector": true,
-              "dismissReason": true,
-              "dismissed_at": false,
-              "firstPatchedVersion": true,
-              "permalink": true,
-              "severity": true,
-              "value": true,
-              "vulnerableVersionRange": false,
-              "withdrawnAt": true
-            },
-            "indexByName": {
-              "advisoryDescription": 6,
-              "created_at": 1,
-              "cvssScore": 9,
-              "cvssVector": 10,
-              "dismissReason": 3,
-              "dismissed_at": 2,
-              "firstPatchedVersion": 7,
-              "packageName": 5,
-              "permalink": 12,
-              "severity": 11,
-              "value": 0,
-              "vulnerableVersionRange": 8,
-              "withdrawnAt": 4
-            },
-            "renameByName": {
-              "created_at": "",
-              "cvssScore": "",
-              "packageName": "package",
-              "permalink": "url",
-              "value": "",
-              "vulnerableVersionRange": "versionRange"
-            }
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "isNotNull",
-                  "options": {}
-                },
-                "fieldName": "dismissed_at"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        }
-      ],
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "grafana-github-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           "mappings": [],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
               },
               {
-                "color": "orange",
-                "value": 70
-              },
-              {
                 "color": "red",
-                "value": 85
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "title"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 323
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 14,
+        "h": 9,
+        "w": 12,
+        "x": 12,
         "y": 16
       },
-      "id": 42,
+      "id": 12,
       "options": {
-<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1268,35 +1163,17 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
-=======
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": true
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-github-datasource",
-            "uid": "${datasource}"
+          "options": {
+            "query": ""
           },
-          "format": 0,
-          "hide": true,
-          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Vulnerabilities",
+          "queryType": "Issues",
           "refId": "A",
-          "repository": "$repository",
-          "severity": 3
+          "repository": "$repository"
         }
       ],
-<<<<<<< HEAD
       "title": "Issues",
       "type": "table"
     },
@@ -1311,104 +1188,56 @@
             "filterable": false,
             "inspect": false
           },
-=======
-      "title": "CVSS Mean",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "advisoryDescription": true,
-              "created_at": true,
-              "cvssVector": true,
-              "dismissReason": true,
-              "dismissed_at": true,
-              "firstPatchedVersion": true,
-              "packageName": true,
-              "permalink": true,
-              "severity": true,
-              "value": true,
-              "vulnerableVersionRange": true,
-              "withdrawnAt": true
-            },
-            "indexByName": {
-              "advisoryDescription": 6,
-              "created_at": 1,
-              "cvssScore": 9,
-              "cvssVector": 10,
-              "dismissReason": 3,
-              "dismissed_at": 2,
-              "firstPatchedVersion": 7,
-              "packageName": 5,
-              "permalink": 12,
-              "severity": 11,
-              "value": 0,
-              "vulnerableVersionRange": 8,
-              "withdrawnAt": 4
-            },
-            "renameByName": {
-              "created_at": "",
-              "cvssScore": "",
-              "packageName": "package",
-              "permalink": "url",
-              "value": "",
-              "vulnerableVersionRange": "versionRange"
-            }
-          }
-        },
-        {
-          "id": "reduce",
-          "options": {
-            "includeTimeField": false,
-            "labelsToFields": true,
-            "mode": "reduceFields",
-            "reducers": [
-              "mean"
-            ]
-          }
-        }
-      ],
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "grafana-github-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           "mappings": [],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
               },
               {
-                "color": "orange",
-                "value": 70
-              },
-              {
                 "color": "red",
-                "value": 85
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 44
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "title"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 259
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 19,
-        "y": 16
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 25
       },
-      "id": 43,
+      "id": 13,
       "options": {
-<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1420,111 +1249,37 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
-=======
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": true
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.4.0-pre",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-github-datasource",
-            "uid": "${datasource}"
+          "options": {
+            "timeField": 1
           },
-          "format": 0,
-          "hide": true,
-          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Vulnerabilities",
+          "queryType": "Pull_Requests",
           "refId": "A",
-          "repository": "$repository",
-          "severity": 3
+          "repository": "$repository"
         }
       ],
-<<<<<<< HEAD
       "title": "Pull Requests",
-=======
-      "title": "Open Known Vulnerable Packages",
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "transformations": [
         {
           "id": "organize",
           "options": {
             "excludeByName": {
-              "advisoryDescription": true,
-              "created_at": true,
-              "cvssVector": true,
-              "dismissReason": true,
-              "dismissed_at": false,
-              "firstPatchedVersion": true,
-              "packageName": true,
-              "permalink": true,
-              "severity": true,
-              "value": true,
-              "vulnerableVersionRange": true,
-              "withdrawnAt": true
+              "author_company": false,
+              "author_email": false,
+              "is_draft": false,
+              "locked": false,
+              "repository": false
             },
-            "indexByName": {
-              "advisoryDescription": 6,
-              "created_at": 1,
-              "cvssScore": 9,
-              "cvssVector": 10,
-              "dismissReason": 3,
-              "dismissed_at": 2,
-              "firstPatchedVersion": 7,
-              "packageName": 5,
-              "permalink": 12,
-              "severity": 11,
-              "value": 0,
-              "vulnerableVersionRange": 8,
-              "withdrawnAt": 4
-            },
-            "renameByName": {
-              "created_at": "",
-              "cvssScore": "",
-              "packageName": "package",
-              "permalink": "url",
-              "value": "",
-              "vulnerableVersionRange": "versionRange"
-            }
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "isNotNull",
-                  "options": {}
-                },
-                "fieldName": "dismissed_at"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "count"
-            ]
+            "indexByName": {},
+            "renameByName": {}
           }
         }
       ],
-      "type": "gauge"
+      "type": "table"
     },
     {
-<<<<<<< HEAD
       "datasource": {
         "uid": "$datasource"
       },
@@ -1534,231 +1289,46 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
-      "collapsed": true,
-      "datasource": {
-        "type": "grafana-github-datasource",
-        "uid": "3CyHZJ2nk"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 37,
-      "panels": [
-        {
-          "datasource": {
-            "uid": "$datasource"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "id"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 74
-                  }
-                ]
+                "color": "green",
+                "value": null
               },
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "author"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 136
-                  }
-                ]
+                "color": "red",
+                "value": 80
               }
             ]
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 25
-          },
-          "id": 2,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "gitRef": "$branch"
-              },
-              "owner": "$organization",
-              "queryType": "Commits",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Commits",
-          "type": "table"
+          }
         },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
             },
-            "overrides": [
+            "properties": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "title"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 323
-                  }
-                ]
+                "id": "custom.width",
+                "value": 380
               }
             ]
           },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 25
-          },
-          "id": 12,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "company"
             },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "query": ""
-              },
-              "owner": "$organization",
-              "queryType": "Issues",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Issues",
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
+            "properties": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "number"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 44
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "title"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 259
-                  }
-                ]
+                "id": "custom.width",
+                "value": 109
               }
             ]
-<<<<<<< HEAD
           }
         ]
       },
@@ -1783,28 +1353,9 @@
       "pluginVersion": "8.5.0",
       "targets": [
         {
-=======
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 34
-          },
-          "id": 13,
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
+            "query": ""
           },
-<<<<<<< HEAD
           "owner": "$organization",
           "queryType": "Contributors",
           "refId": "A",
@@ -1824,125 +1375,22 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "timeField": 1
-              },
-              "owner": "$organization",
-              "queryType": "Pull_Requests",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Pull Requests",
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "author_company": false,
-                  "author_email": false,
-                  "is_draft": false,
-                  "locked": false,
-                  "repository": false
-                },
-                "indexByName": {},
-                "renameByName": {}
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "id"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 380
-                  }
-                ]
+                "color": "green",
+                "value": null
               },
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "company"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 109
-                  }
-                ]
+                "color": "red",
+                "value": 80
               }
             ]
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 34
-          },
-          "id": 17,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "query": ""
-              },
-              "owner": "$organization",
-              "queryType": "Contributors",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Contributors",
-          "type": "table"
+          }
         },
-<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -1964,53 +1412,10 @@
       },
       "pluginVersion": "8.5.0",
       "targets": [
-=======
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 43
-          },
-          "id": 24,
           "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
+            "query": ""
           },
-<<<<<<< HEAD
           "owner": "$organization",
           "queryType": "Milestones",
           "refId": "A",
@@ -2030,86 +1435,22 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "query": ""
-              },
-              "owner": "$organization",
-              "queryType": "Milestones",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Milestones",
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 43
-          },
-          "id": 18,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "desc": false,
-                "displayName": "login"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "owner": "$organization",
-              "queryType": "Releases",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Releases",
-          "type": "table"
+          }
         },
-<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -2157,48 +1498,34 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
-        {
-          "datasource": {
-            "uid": "$datasource"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "author_email"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 155
-                  }
-                ]
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
-<<<<<<< HEAD
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "author_email"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 155
+              }
+            ]
           }
         ]
       },
@@ -2242,100 +1569,22 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-=======
           },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 52
-          },
-          "id": 11,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "owner": "$organization",
-              "queryType": "Tags",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Tags",
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "displayMode": "auto",
-                "filterable": false
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
+              {
+                "color": "red",
+                "value": 80
               }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 52
-          },
-          "id": 23,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "options": {
-                "names": "",
-                "packageType": "NPM"
-              },
-              "owner": "$organization",
-              "queryType": "Packages",
-              "refId": "A",
-              "repository": "$repository"
-            }
-          ],
-          "title": "Packages",
-          "type": "table"
+            ]
+          }
         },
-<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -2357,115 +1606,23 @@
       },
       "pluginVersion": "8.5.0",
       "targets": [
-=======
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         {
-          "datasource": {
-            "type": "grafana-github-datasource",
-            "uid": "${datasource}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "displayMode": "auto"
-              },
-              "links": [
-                {
-                  "targetBlank": true,
-                  "title": "",
-                  "url": "${__data.fields.permalink}"
-                }
-              ],
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "packageName"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 283
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 61
-          },
-          "id": 45,
           "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
+            "names": "",
+            "packageType": "NPM"
           },
-          "pluginVersion": "8.4.0-pre",
-          "targets": [
-            {
-              "datasource": {
-                "type": "grafana-github-datasource",
-                "uid": "${datasource}"
-              },
-              "format": 0,
-              "metric": "issues",
-              "options": {
-                "query": ""
-              },
-              "owner": "$organization",
-              "queryType": "Vulnerabilities",
-              "refId": "A",
-              "repository": "$repository",
-              "severity": 3
-            }
-          ],
-          "title": "Vulnerability Alerts",
-          "type": "table"
+          "owner": "$organization",
+          "queryType": "Packages",
+          "refId": "A",
+          "repository": "$repository"
         }
       ],
-<<<<<<< HEAD
       "title": "Packages",
       "type": "table"
     }
   ],
   "refresh": false,
   "schemaVersion": 36,
-=======
-      "title": "Data",
-      "type": "row"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 34,
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2509,21 +1666,10 @@
         "type": "textbox"
       },
       {
-<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
-=======
-        "current": {
-          "selected": false,
-          "text": "grafana",
-          "value": "grafana"
-        },
-        "datasource": {
-          "type": "grafana-github-datasource",
-          "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Repositories",
         "hide": 0,
@@ -2549,21 +1695,10 @@
       },
       {
         "allValue": "",
-<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
-=======
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "grafana-github-datasource",
-          "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Labels",
         "hide": 0,
@@ -2611,21 +1746,10 @@
         "type": "custom"
       },
       {
-<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
-=======
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "grafana-github-datasource",
-          "uid": "3CyHZJ2nk"
->>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Milestones",
         "hide": 0,

--- a/src/dashboards/dashboard.json
+++ b/src/dashboards/dashboard.json
@@ -1,41 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GITHUB",
-      "label": "GitHub",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-github-datasource",
-      "pluginName": "GitHub"
-    }
-  ],
-  "__elements": [],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.5.0"
-    },
-    {
-      "type": "datasource",
-      "id": "grafana-github-datasource",
-      "name": "GitHub",
-      "version": "1.0.8"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -131,8 +94,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+<<<<<<< HEAD
   "id": null,
   "iteration": 1654462304304,
+=======
+  "id": 1,
+  "iteration": 1639085936786,
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
   "links": [],
   "liveNow": false,
   "panels": [
@@ -140,7 +108,11 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
+<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
+=======
+        "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -198,7 +170,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.3.1",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -268,7 +244,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.3.1",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "owner": "$organization",
@@ -335,7 +315,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "owner": "$organization",
@@ -361,7 +345,11 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
+<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
+=======
+        "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -415,7 +403,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -490,7 +482,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -562,7 +558,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -645,7 +645,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -685,7 +689,11 @@
       "collapsed": false,
       "datasource": {
         "type": "grafana-github-datasource",
+<<<<<<< HEAD
         "uid": "${DS_GITHUB}"
+=======
+        "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       },
       "gridPos": {
         "h": 1,
@@ -743,7 +751,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -817,7 +829,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -888,7 +904,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -975,7 +995,11 @@
         "text": {},
         "textMode": "auto"
       },
+<<<<<<< HEAD
       "pluginVersion": "8.5.0",
+=======
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
           "options": {
@@ -1002,23 +1026,27 @@
     },
     {
       "collapsed": false,
+<<<<<<< HEAD
       "datasource": {
         "type": "grafana-github-datasource",
         "uid": "${DS_GITHUB}"
       },
+=======
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 15
       },
-      "id": 37,
+      "id": 39,
       "panels": [],
-      "title": "Data",
+      "title": "Security",
       "type": "row"
     },
     {
       "datasource": {
+<<<<<<< HEAD
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1027,57 +1055,53 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
+=======
+        "type": "grafana-github-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
+          "links": [],
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
               },
               {
-                "color": "red",
-                "value": 80
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "dark-red",
+                "value": 9
               }
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "id"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 74
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "author"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 136
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 8,
+        "w": 14,
         "x": 0,
         "y": 16
       },
-      "id": 2,
+      "id": 41,
       "options": {
+<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1089,17 +1113,35 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
+=======
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/^cvssScore$/",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "options": {
-            "gitRef": "$branch"
+          "datasource": {
+            "type": "grafana-github-datasource",
+            "uid": "${datasource}"
           },
+          "format": 0,
+          "hide": true,
+          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Commits",
+          "queryType": "Vulnerabilities",
           "refId": "A",
-          "repository": "$repository"
+          "repository": "$repository",
+          "severity": 3
         }
       ],
+<<<<<<< HEAD
       "title": "Commits",
       "type": "table"
     },
@@ -1114,44 +1156,107 @@
             "filterable": false,
             "inspect": false
           },
+=======
+      "title": "Vulnerability CVSS Scores for $repository",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "advisoryDescription": true,
+              "cvssVector": true,
+              "dismissReason": true,
+              "dismissed_at": false,
+              "firstPatchedVersion": true,
+              "permalink": true,
+              "severity": true,
+              "value": true,
+              "vulnerableVersionRange": false,
+              "withdrawnAt": true
+            },
+            "indexByName": {
+              "advisoryDescription": 6,
+              "created_at": 1,
+              "cvssScore": 9,
+              "cvssVector": 10,
+              "dismissReason": 3,
+              "dismissed_at": 2,
+              "firstPatchedVersion": 7,
+              "packageName": 5,
+              "permalink": 12,
+              "severity": 11,
+              "value": 0,
+              "vulnerableVersionRange": 8,
+              "withdrawnAt": 4
+            },
+            "renameByName": {
+              "created_at": "",
+              "cvssScore": "",
+              "packageName": "package",
+              "permalink": "url",
+              "value": "",
+              "vulnerableVersionRange": "versionRange"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "isNotNull",
+                  "options": {}
+                },
+                "fieldName": "dismissed_at"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-github-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           "mappings": [],
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",
                 "value": null
               },
               {
+                "color": "orange",
+                "value": 70
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 85
               }
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "title"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 323
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
+        "h": 8,
+        "w": 5,
+        "x": 14,
         "y": 16
       },
-      "id": 12,
+      "id": 42,
       "options": {
+<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1163,17 +1268,35 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
+=======
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "options": {
-            "query": ""
+          "datasource": {
+            "type": "grafana-github-datasource",
+            "uid": "${datasource}"
           },
+          "format": 0,
+          "hide": true,
+          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Issues",
+          "queryType": "Vulnerabilities",
           "refId": "A",
-          "repository": "$repository"
+          "repository": "$repository",
+          "severity": 3
         }
       ],
+<<<<<<< HEAD
       "title": "Issues",
       "type": "table"
     },
@@ -1188,56 +1311,104 @@
             "filterable": false,
             "inspect": false
           },
+=======
+      "title": "CVSS Mean",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "advisoryDescription": true,
+              "created_at": true,
+              "cvssVector": true,
+              "dismissReason": true,
+              "dismissed_at": true,
+              "firstPatchedVersion": true,
+              "packageName": true,
+              "permalink": true,
+              "severity": true,
+              "value": true,
+              "vulnerableVersionRange": true,
+              "withdrawnAt": true
+            },
+            "indexByName": {
+              "advisoryDescription": 6,
+              "created_at": 1,
+              "cvssScore": 9,
+              "cvssVector": 10,
+              "dismissReason": 3,
+              "dismissed_at": 2,
+              "firstPatchedVersion": 7,
+              "packageName": 5,
+              "permalink": 12,
+              "severity": 11,
+              "value": 0,
+              "vulnerableVersionRange": 8,
+              "withdrawnAt": 4
+            },
+            "renameByName": {
+              "created_at": "",
+              "cvssScore": "",
+              "packageName": "package",
+              "permalink": "url",
+              "value": "",
+              "vulnerableVersionRange": "versionRange"
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "labelsToFields": true,
+            "mode": "reduceFields",
+            "reducers": [
+              "mean"
+            ]
+          }
+        }
+      ],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-github-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           "mappings": [],
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",
                 "value": null
               },
               {
+                "color": "orange",
+                "value": 70
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 85
               }
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "number"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 44
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "title"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 259
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 25
+        "h": 8,
+        "w": 5,
+        "x": 19,
+        "y": 16
       },
-      "id": 13,
+      "id": 43,
       "options": {
+<<<<<<< HEAD
         "footer": {
           "fields": "",
           "reducer": [
@@ -1249,37 +1420,111 @@
         "sortBy": []
       },
       "pluginVersion": "8.5.0",
+=======
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.0-pre",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "targets": [
         {
-          "options": {
-            "timeField": 1
+          "datasource": {
+            "type": "grafana-github-datasource",
+            "uid": "${datasource}"
           },
+          "format": 0,
+          "hide": true,
+          "metric": "issues",
           "owner": "$organization",
-          "queryType": "Pull_Requests",
+          "queryType": "Vulnerabilities",
           "refId": "A",
-          "repository": "$repository"
+          "repository": "$repository",
+          "severity": 3
         }
       ],
+<<<<<<< HEAD
       "title": "Pull Requests",
+=======
+      "title": "Open Known Vulnerable Packages",
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
       "transformations": [
         {
           "id": "organize",
           "options": {
             "excludeByName": {
-              "author_company": false,
-              "author_email": false,
-              "is_draft": false,
-              "locked": false,
-              "repository": false
+              "advisoryDescription": true,
+              "created_at": true,
+              "cvssVector": true,
+              "dismissReason": true,
+              "dismissed_at": false,
+              "firstPatchedVersion": true,
+              "packageName": true,
+              "permalink": true,
+              "severity": true,
+              "value": true,
+              "vulnerableVersionRange": true,
+              "withdrawnAt": true
             },
-            "indexByName": {},
-            "renameByName": {}
+            "indexByName": {
+              "advisoryDescription": 6,
+              "created_at": 1,
+              "cvssScore": 9,
+              "cvssVector": 10,
+              "dismissReason": 3,
+              "dismissed_at": 2,
+              "firstPatchedVersion": 7,
+              "packageName": 5,
+              "permalink": 12,
+              "severity": 11,
+              "value": 0,
+              "vulnerableVersionRange": 8,
+              "withdrawnAt": 4
+            },
+            "renameByName": {
+              "created_at": "",
+              "cvssScore": "",
+              "packageName": "package",
+              "permalink": "url",
+              "value": "",
+              "vulnerableVersionRange": "versionRange"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "isNotNull",
+                  "options": {}
+                },
+                "fieldName": "dismissed_at"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "count"
+            ]
           }
         }
       ],
-      "type": "table"
+      "type": "gauge"
     },
     {
+<<<<<<< HEAD
       "datasource": {
         "uid": "$datasource"
       },
@@ -1289,46 +1534,231 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
+=======
+      "collapsed": true,
+      "datasource": {
+        "type": "grafana-github-datasource",
+        "uid": "3CyHZJ2nk"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 37,
+      "panels": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": {
+                  "id": "byName",
+                  "options": "id"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 74
+                  }
+                ]
               },
               {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "id"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 380
+                "matcher": {
+                  "id": "byName",
+                  "options": "author"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 136
+                  }
+                ]
               }
             ]
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "company"
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 2,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
             },
-            "properties": [
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "gitRef": "$branch"
+              },
+              "owner": "$organization",
+              "queryType": "Commits",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Commits",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
               {
-                "id": "custom.width",
-                "value": 109
+                "matcher": {
+                  "id": "byName",
+                  "options": "title"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 323
+                  }
+                ]
               }
             ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "id": 12,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "query": ""
+              },
+              "owner": "$organization",
+              "queryType": "Issues",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Issues",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "number"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 44
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "title"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 259
+                  }
+                ]
+              }
+            ]
+<<<<<<< HEAD
           }
         ]
       },
@@ -1353,9 +1783,28 @@
       "pluginVersion": "8.5.0",
       "targets": [
         {
-          "options": {
-            "query": ""
+=======
           },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 13,
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+<<<<<<< HEAD
           "owner": "$organization",
           "queryType": "Contributors",
           "refId": "A",
@@ -1375,22 +1824,125 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
+=======
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "timeField": 1
+              },
+              "owner": "$organization",
+              "queryType": "Pull_Requests",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Pull Requests",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "author_company": false,
+                  "author_email": false,
+                  "is_draft": false,
+                  "locked": false,
+                  "repository": false
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": {
+                  "id": "byName",
+                  "options": "id"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 380
+                  }
+                ]
               },
               {
-                "color": "red",
-                "value": 80
+                "matcher": {
+                  "id": "byName",
+                  "options": "company"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 109
+                  }
+                ]
               }
             ]
-          }
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "query": ""
+              },
+              "owner": "$organization",
+              "queryType": "Contributors",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Contributors",
+          "type": "table"
         },
+<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -1412,10 +1964,53 @@
       },
       "pluginVersion": "8.5.0",
       "targets": [
+=======
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         {
-          "options": {
-            "query": ""
+          "datasource": {
+            "uid": "$datasource"
           },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 24,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+<<<<<<< HEAD
           "owner": "$organization",
           "queryType": "Milestones",
           "refId": "A",
@@ -1435,22 +2030,86 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+=======
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "query": ""
               },
+              "owner": "$organization",
+              "queryType": "Milestones",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Milestones",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 18,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
               {
-                "color": "red",
-                "value": 80
+                "desc": false,
+                "displayName": "login"
               }
             ]
-          }
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "owner": "$organization",
+              "queryType": "Releases",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Releases",
+          "type": "table"
         },
+<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -1498,34 +2157,48 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
+=======
+        {
+          "datasource": {
+            "uid": "$datasource"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
               },
-              {
-                "color": "red",
-                "value": 80
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "author_email"
             },
-            "properties": [
+            "overrides": [
               {
-                "id": "custom.width",
-                "value": 155
+                "matcher": {
+                  "id": "byName",
+                  "options": "author_email"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 155
+                  }
+                ]
               }
             ]
+<<<<<<< HEAD
           }
         ]
       },
@@ -1569,22 +2242,100 @@
             "displayMode": "auto",
             "filterable": false,
             "inspect": false
+=======
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 11,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "owner": "$organization",
+              "queryType": "Tags",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Tags",
+          "type": "table"
         },
+        {
+          "datasource": {
+            "uid": "$datasource"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 23,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "options": {
+                "names": "",
+                "packageType": "NPM"
+              },
+              "owner": "$organization",
+              "queryType": "Packages",
+              "refId": "A",
+              "repository": "$repository"
+            }
+          ],
+          "title": "Packages",
+          "type": "table"
+        },
+<<<<<<< HEAD
         "overrides": []
       },
       "gridPos": {
@@ -1606,23 +2357,115 @@
       },
       "pluginVersion": "8.5.0",
       "targets": [
+=======
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         {
-          "options": {
-            "names": "",
-            "packageType": "NPM"
+          "datasource": {
+            "type": "grafana-github-datasource",
+            "uid": "${datasource}"
           },
-          "owner": "$organization",
-          "queryType": "Packages",
-          "refId": "A",
-          "repository": "$repository"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "",
+                  "url": "${__data.fields.permalink}"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "packageName"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 283
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 45,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.4.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-github-datasource",
+                "uid": "${datasource}"
+              },
+              "format": 0,
+              "metric": "issues",
+              "options": {
+                "query": ""
+              },
+              "owner": "$organization",
+              "queryType": "Vulnerabilities",
+              "refId": "A",
+              "repository": "$repository",
+              "severity": 3
+            }
+          ],
+          "title": "Vulnerability Alerts",
+          "type": "table"
         }
       ],
+<<<<<<< HEAD
       "title": "Packages",
       "type": "table"
     }
   ],
   "refresh": false,
   "schemaVersion": 36,
+=======
+      "title": "Data",
+      "type": "row"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 34,
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1666,10 +2509,21 @@
         "type": "textbox"
       },
       {
+<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
+=======
+        "current": {
+          "selected": false,
+          "text": "grafana",
+          "value": "grafana"
+        },
+        "datasource": {
+          "type": "grafana-github-datasource",
+          "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Repositories",
         "hide": 0,
@@ -1695,10 +2549,21 @@
       },
       {
         "allValue": "",
+<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
+=======
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-github-datasource",
+          "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Labels",
         "hide": 0,
@@ -1746,10 +2611,21 @@
         "type": "custom"
       },
       {
+<<<<<<< HEAD
         "current": {},
         "datasource": {
           "type": "grafana-github-datasource",
           "uid": "${DS_GITHUB}"
+=======
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-github-datasource",
+          "uid": "3CyHZJ2nk"
+>>>>>>> 24ac212 (Add vulnerabilities to the default dashboard)
         },
         "definition": "GitHub - Milestones",
         "hide": 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export enum QueryType {
   GraphQL = 'GraphQL',
   Milestones = 'Milestones',
   Packages = 'Packages',
+  Vulnerabilities = 'Vulnerabilities',
 }
 
 export enum PackageType {

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -17,6 +17,7 @@ import QueryEditorTags from './QueryEditorTags';
 import QueryEditorContributors from './QueryEditorContributors';
 import QueryEditorLabels from './QueryEditorLabels';
 import QueryEditorPackages from './QueryEditorPackages';
+import QueryEditorVulnerabilities from './QueryEditorVulnerabilities';
 
 interface Props extends QueryEditorProps<DataSource, GitHubQuery, GithubDataSourceOptions> {
   queryTypes?: string[];
@@ -70,6 +71,11 @@ const queryEditors: {
   [QueryType.Pull_Requests]: {
     component: (props: Props, onChange: (val: any) => void) => (
       <QueryEditorPullRequests {...(props.query.options || {})} onChange={onChange} />
+    ),
+  },
+  [QueryType.Vulnerabilities]: {
+    component: (props: Props, onChange: (val: any) => void) => (
+      <QueryEditorVulnerabilities {...(props.query.options || {})} onChange={onChange} />
     ),
   },
 };

--- a/src/views/QueryEditorVulnerabilities.tsx
+++ b/src/views/QueryEditorVulnerabilities.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Input } from '@grafana/ui';
+
+import { QueryInlineField } from '../components/Forms';
+import { LabelsOptions } from '../types';
+import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+
+interface Props extends LabelsOptions {
+  onChange: (value: LabelsOptions) => void;
+}
+
+const QueryEditorVulnerabilities = (props: Props) => {
+  const [query, setQuery] = useState<string>(props.query || '');
+  return (
+    <>
+      <QueryInlineField labelWidth={LeftColumnWidth} label="Query (optional)">
+        <Input
+          css=""
+          width={RightColumnWidth}
+          value={query}
+          onChange={(el) => setQuery(el.currentTarget.value)}
+          onBlur={(el) => props.onChange({ ...props, query: el.currentTarget.value })}
+        />
+      </QueryInlineField>
+    </>
+  );
+};
+
+export default QueryEditorVulnerabilities;


### PR DESCRIPTION
GitHub added vulnerability (dependabot) alerts as something you can query via the API so this enhancement lets you query that from the GitHub Datasource in Grafana.

Note this was done as part of a hackathon in 2021. I just rebased off of main and retested. Seemed to work. 