### PR TITLE
Query: Add query to fetch stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The GitHub datasource allows GitHub API data to be visually represented in Grafana dashboards.
 
-## Github API V4 (graphql)
+## GitHub API V4 (GraphQL)
 
 This datasource uses the [`githubv4` package](https://github.com/shurcooL/githubv4), which is under active development.
 
@@ -13,6 +13,7 @@ This datasource uses the [`githubv4` package](https://github.com/shurcooL/github
 - [x] Releases
 - [x] Commits
 - [x] Repositories
+- [x] Stargazers
 - [x] Issues
 - [x] Organizations
 - [x] Labels
@@ -40,7 +41,7 @@ Options:
 | Access token          | true     |
 | Default Organization  | false    |
 | Default Repository    | true     |
-| Github Enterprise URL | false    |
+| GitHub Enterprise URL | false    |
 
 To create a new Access Token, navigate to [Personal Access Tokens](https://github.com/settings/tokens) and press **Generate new token.**
 

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -149,6 +149,16 @@ func (d *Datasource) HandleProjectsQuery(ctx context.Context, query *models.Proj
 	return projects.GetAllProjects(ctx, d.client, opt)
 }
 
+// HandleStargazersQuery is the query handler for listing stargazers of a GitHub repository
+func (d *Datasource) HandleStargazersQuery(ctx context.Context, query *models.StargazersQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.ListStargazersOptions{
+		Repository: query.Repository,
+		Owner:      query.Owner,
+	}
+
+	return GetStargazers(ctx, d.client, opt, req.TimeRange)
+}
+
 // CheckHealth is the health check for GitHub
 func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	_, err := GetAllRepositories(ctx, d.client, models.ListRepositoriesOptions{

--- a/pkg/github/query_handler.go
+++ b/pkg/github/query_handler.go
@@ -54,6 +54,7 @@ func GetQueryHandlers(s *QueryHandler) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypeRepositories, s.HandleRepositories)
 	mux.HandleFunc(models.QueryTypeVulnerabilities, s.HandleVulnerabilities)
 	mux.HandleFunc(models.QueryTypeProjects, s.HandleProjects)
+	mux.HandleFunc(models.QueryTypeStargazers, s.HandleStargazers)
 
 	return mux
 }

--- a/pkg/github/stargazers.go
+++ b/pkg/github/stargazers.go
@@ -1,0 +1,148 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/pkg/errors"
+	"github.com/shurcooL/githubv4"
+)
+
+// QueryStargazers is the object representation of the graphql query for retrieving a paginated list of stargazers for a repository
+//
+//	query {
+//		repository(owner: $owner, name: $name) {
+//			stargazers(first: 100, orderBy: {field: STARRED_AT, direction: DESC}, after: $cursor) {
+//				totalCount
+//				pageInfo {
+//					hasNextPage
+//					startCursor
+//					endCursor
+//				}
+//				edges {
+//					starredAt
+//					node {
+//						id
+//						login
+//						name
+//						company
+//						email
+//						url
+//					}
+//				}
+//			}
+//		}
+//	}
+type QueryStargazers struct {
+	Repository struct {
+		Stargazers struct {
+			TotalCount int64
+			PageInfo   models.PageInfo
+			Edges      []Stargazer
+		} `graphql:"stargazers(first: 100, orderBy: {field: STARRED_AT, direction: DESC}, after: $cursor)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// Stargazer a GitHub user tied to when they starred the repository
+type Stargazer struct {
+	StarredAt githubv4.DateTime
+	Node      models.User
+}
+
+// StargazerWrapper is a mapping of a GitHub stargazer to what the total count
+// of stars roughly would've been when they starred the repository
+type StargazerWrapper struct {
+	Stargazer
+	StarCount int64
+}
+
+// StargazersWrapper is a list of GitHub wrapped stargazers
+type StargazersWrapper []StargazerWrapper
+
+// Frames converts the list of stargazers to a Grafana DataFrame
+func (a StargazersWrapper) Frames() data.Frames {
+	frame := data.NewFrame(
+		"stargazers",
+		data.NewField("starred_at", nil, []time.Time{}),
+		data.NewField("star_count", nil, []int64{}),
+		data.NewField("id", nil, []string{}),
+		data.NewField("login", nil, []string{}),
+		data.NewField("git_name", nil, []string{}),
+		data.NewField("company", nil, []string{}),
+		data.NewField("email", nil, []string{}),
+		data.NewField("url", nil, []string{}),
+	)
+
+	for _, v := range a {
+		node := v.Stargazer.Node
+
+		frame.InsertRow(
+			0,
+			v.StarredAt.Time,
+			v.StarCount,
+			node.ID,
+			node.Login,
+			node.Name,
+			node.Company,
+			node.Email,
+			node.URL,
+		)
+	}
+
+	frame.Meta = &data.FrameMeta{PreferredVisualization: data.VisTypeGraph}
+	return data.Frames{frame}
+}
+
+// GetStargazers gets all stargazers for a GitHub repository
+func GetStargazers(ctx context.Context, client models.Client, opts models.ListStargazersOptions, timeRange backend.TimeRange) (StargazersWrapper, error) {
+	var (
+		variables = map[string]interface{}{
+			"cursor": (*githubv4.String)(nil),
+			"owner":  githubv4.String(opts.Owner),
+			"name":   githubv4.String(opts.Repository),
+		}
+
+		stargazers = StargazersWrapper{}
+
+		totalCountRemaining int64
+	)
+
+	for {
+		q := &QueryStargazers{}
+
+		if err := client.Query(ctx, q, variables); err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		if totalCountRemaining == 0 {
+			totalCountRemaining = q.Repository.Stargazers.TotalCount
+		}
+
+		edges := q.Repository.Stargazers.Edges
+
+		for _, v := range edges {
+			time := v.StarredAt.Time
+
+			if time.Before(timeRange.From) {
+				return stargazers, nil
+			}
+
+			if !time.After(timeRange.To) {
+				stargazers = append(stargazers, StargazerWrapper{Stargazer: v, StarCount: totalCountRemaining})
+			}
+
+			totalCountRemaining--
+		}
+
+		if !q.Repository.Stargazers.PageInfo.HasNextPage {
+			break
+		}
+
+		variables["cursor"] = q.Repository.Stargazers.PageInfo.EndCursor
+	}
+
+	return stargazers, nil
+}

--- a/pkg/github/stargazers_handler.go
+++ b/pkg/github/stargazers_handler.go
@@ -1,0 +1,24 @@
+package github
+
+import (
+	"context"
+
+	"github.com/grafana/github-datasource/pkg/dfutil"
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func (s *QueryHandler) handleStargazersQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+	query := &models.StargazersQuery{}
+	if err := UnmarshalQuery(q.JSON, query); err != nil {
+		return *err
+	}
+	return dfutil.FrameResponseWithError(s.Datasource.HandleStargazersQuery(ctx, query, q))
+}
+
+// HandleStargazers handles the plugin query for GitHub stargazers
+func (s *QueryHandler) HandleStargazers(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return &backend.QueryDataResponse{
+		Responses: processQueries(ctx, req, s.handleStargazersQuery),
+	}, nil
+}

--- a/pkg/github/stargazers_test.go
+++ b/pkg/github/stargazers_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/github-datasource/pkg/testutil"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/shurcooL/githubv4"
+)
+
+func TestGetStargazers(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		opts = models.ListStargazersOptions{
+			Owner:      "grafana",
+			Repository: "grafana",
+		}
+		timeRange = backend.TimeRange{
+			From: time.Now().Add(-7 * 24 * time.Hour),
+			To:   time.Now(),
+		}
+	)
+
+	testVariables := testutil.GetTestVariablesFunction("name", "owner", "cursor")
+
+	client := testutil.NewTestClient(t,
+		testVariables,
+		testutil.GetTestQueryFunction(&QueryStargazers{}),
+	)
+
+	_, err := GetStargazers(ctx, client, opts, timeRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStargazersDataframe(t *testing.T) {
+	starredAt, err := time.Parse(time.RFC3339, "2023-01-14T10:25:41+00:00")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stargazers := StargazersWrapper{
+		StargazerWrapper{
+			Stargazer: Stargazer{
+				StarredAt: githubv4.DateTime{
+					Time: starredAt,
+				},
+				Node: models.User{
+					ID:      "NEVER",
+					Login:   "gonna",
+					Name:    "Give",
+					Company: "You",
+					Email:   "up@example.org",
+				},
+			},
+			StarCount: 1,
+		},
+		StargazerWrapper{
+			Stargazer: Stargazer{
+				StarredAt: githubv4.DateTime{
+					Time: starredAt.Add(time.Minute * -2),
+				},
+				Node: models.User{
+					ID:      "NEVER",
+					Login:   "gonna",
+					Name:    "Let",
+					Company: "You",
+					Email:   "down@example.org",
+				},
+			},
+			StarCount: 2,
+		},
+		StargazerWrapper{
+			Stargazer: Stargazer{
+				StarredAt: githubv4.DateTime{
+					Time: starredAt.Add(time.Minute * -4),
+				},
+				Node: models.User{
+					ID:      "NEVER",
+					Login:   "gonna",
+					Name:    "Run",
+					Company: "Around",
+					Email:   "and_desert_you@example.org",
+					URL:     "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+				},
+			},
+			StarCount: 3,
+		},
+	}
+
+	testutil.CheckGoldenFramer(t, "stargazers", stargazers)
+}

--- a/pkg/github/testdata/stargazers.golden.jsonc
+++ b/pkg/github/testdata/stargazers.golden.jsonc
@@ -1,0 +1,134 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "preferredVisualisationType": "graph"
+//  }
+//  Name: stargazers
+//  Dimensions: 8 Fields by 3 Rows
+//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  | Name: starred_at              | Name: star_count | Name: id       | Name: login    | Name: git_name | Name: company  | Name: email                | Name: url                                   |
+//  | Labels:                       | Labels:          | Labels:        | Labels:        | Labels:        | Labels:        | Labels:                    | Labels:                                     |
+//  | Type: []time.Time             | Type: []int64    | Type: []string | Type: []string | Type: []string | Type: []string | Type: []string             | Type: []string                              |
+//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  | 2023-01-14 10:21:41 +0000 GMT | 3                | NEVER          | gonna          | Run            | Around         | and_desert_you@example.org | https://www.youtube.com/watch?v=dQw4w9WgXcQ |
+//  | 2023-01-14 10:23:41 +0000 GMT | 2                | NEVER          | gonna          | Let            | You            | down@example.org           |                                             |
+//  | 2023-01-14 10:25:41 +0000 GMT | 1                | NEVER          | gonna          | Give           | You            | up@example.org             |                                             |
+//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "stargazers",
+        "meta": {
+          "preferredVisualisationType": "graph"
+        },
+        "fields": [
+          {
+            "name": "starred_at",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "star_count",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            }
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "login",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "git_name",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "company",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "email",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "url",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1673691701000,
+            1673691821000,
+            1673691941000
+          ],
+          [
+            3,
+            2,
+            1
+          ],
+          [
+            "NEVER",
+            "NEVER",
+            "NEVER"
+          ],
+          [
+            "gonna",
+            "gonna",
+            "gonna"
+          ],
+          [
+            "Run",
+            "Let",
+            "Give"
+          ],
+          [
+            "Around",
+            "You",
+            "You"
+          ],
+          [
+            "and_desert_you@example.org",
+            "down@example.org",
+            "up@example.org"
+          ],
+          [
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "",
+            ""
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -31,6 +31,8 @@ const (
 	QueryTypeProjects = "Projects"
 	// QueryTypeProjectItems is used when querying projects for an organization
 	QueryTypeProjectItems = "ProjectItems"
+	// QueryTypeStargazers is used when querying stargazers for a repository
+	QueryTypeStargazers = "Stargazers"
 )
 
 // Query refers to the structure of a query built using the QueryEditor.
@@ -105,4 +107,9 @@ type MilestonesQuery struct {
 type VulnerabilityQuery struct {
 	Query
 	Options ListVulnerabilitiesOptions `json:"options"`
+}
+
+// StargazersQuery is used when querying stargazers for a repository
+type StargazersQuery struct {
+	Query
 }

--- a/pkg/models/stargazers.go
+++ b/pkg/models/stargazers.go
@@ -1,0 +1,10 @@
+package models
+
+// ListStargazersOptions is provided when fetching stargazers for a repository
+type ListStargazersOptions struct {
+	// Owner is the owner of the repository (ex: grafana)
+	Owner string `json:"owner"`
+
+	// Repository is the name of the repository being queried (ex: grafana)
+	Repository string `json:"repository"`
+}

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -22,6 +22,7 @@ type Datasource interface {
 	HandleMilestonesQuery(context.Context, *models.MilestonesQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleVulnerabilitiesQuery(context.Context, *models.VulnerabilityQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleProjectsQuery(context.Context, *models.ProjectsQuery, backend.DataQuery) (dfutil.Framer, error)
+	HandleStargazersQuery(context.Context, *models.StargazersQuery, backend.DataQuery) (dfutil.Framer, error)
 	CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error)
 	QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error)
 }

--- a/pkg/plugin/datasource_caching.go
+++ b/pkg/plugin/datasource_caching.go
@@ -202,6 +202,16 @@ func (c *CachedDatasource) HandleProjectsQuery(ctx context.Context, q *models.Pr
 	return c.saveCache(req, f, err)
 }
 
+// HandleStargazersQuery is the cache wrapper for the stargazer query handler
+func (c *CachedDatasource) HandleStargazersQuery(ctx context.Context, q *models.StargazersQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	if value, err := c.getCache(req); err == nil {
+		return value, err
+	}
+
+	f, err := c.datasource.HandleStargazersQuery(ctx, q, req)
+	return c.saveCache(req, f, err)
+}
+
 // CheckHealth forwards the request to the datasource and does not perform any caching
 func (c *CachedDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	return c.datasource.CheckHealth(ctx, req)

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export enum QueryType {
   Vulnerabilities = 'Vulnerabilities',
   Projects = 'Projects',
   ProjectItems = 'ProjectItems',
+  Stargazers = 'Stargazers',
 }
 
 export enum PackageType {

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -85,6 +85,9 @@ const queryEditors: {
       <QueryEditorProjects {...(props.query.options || {})} onChange={onChange} />
     ),
   },
+  [QueryType.Stargazers]: {
+    component: (_: Props, onChange: (val: any) => void) => <></>,
+  },
 };
 
 /* eslint-enable react/display-name */


### PR DESCRIPTION
Adds a Stargazers query to the list of available queries in the GitHub datasource.

#### Motivation

I wanted a way to visualize/monitor GitHub star counts and monitor how specific events would impact it. For example, when a YouTuber recommends an open-source tool to viewers.

Existing solutions outside of Grafana do exist, but only give an end-to-end view of star counts across the entire repository lifetime. They're not interactive, so we can't annotate it or focus on particular periods of time.

### Implementation Details

#### Timestamps

Unlike other queries/endpoints like Commits, there is no way to specify `since` and `until`. I decided the best approach was to paginate GitHub as normal, but sort the results in DESC order and just stop when we leave the range.

So queries for data like `now-5m` or `now-1M` are very quick, even for large repositories like `grafana/grafana` or `tldr-pages/tldr`. However, queries will take much longer if you want to query older data as the API has to paginate through more results.

I think this is appropriate as querying old data or a full repos lifetime likely to be a one-off action. Queries that execute at set intervals (to monitor milestones for example) will often look at recent data only which will perform very well.

#### `StargazerWrapper`

You'll see that there's a `Stargazer` struct, but also a `StargazerWrapper` struct. I take the total number of stargazers and assign a number to them called `star_count` which represents what star they represent relative to the total star count.

In the docstring I say the following:
> what the total count of stars roughly would've been when they starred the repository

This is because the implementation doesn't account for unstarring a repository. Unfortunately, since the GitHub API returns no such data, this is as close as we can get, but is still a good overall representation.

The only way to get a more accurate measure right now would be to poll the API and actually store the total count somewhere, but that wouldn't cover historic data, and would require external storage and so would be out of scope for a data source plugin.

### Open Questions

#### Default to Visualization

I'm still looking at this, but may opt to do it in a separate PR since I'm still reading through the docs on plugin development.

It'd be nice if the Stargazer query would default to the visual view (graph) instead of doing a table by default. Would you be cool with that, or do you prefer keeping things consistent with just doing a table?

#### Grafana Transformations

Instead of making the `StargazerWrapper` object, I wonder if we can just use a Grafana transformation for this. 🤔 I've only skimmed the docs for now, but it doesn't look possible to me, but advice is welcome if it should be possible.

https://grafana.com/docs/grafana/latest/panels/transform-data/

### Screenshots

![image](https://user-images.githubusercontent.com/22801583/183285134-9b0f4a61-4ee0-4a06-9a5f-9630c4d642c3.png)
> Dashboard showing the star counts of 4 Grafana repos.

![image](https://user-images.githubusercontent.com/22801583/183287781-8de64d18-3d82-4a2c-b968-18f2397e3325.png)
> Dashboard showing star counts for all 4 repositories in a single graph… though it doesn't work so well when 1 has overwhelmingly more.

![Untitled](https://user-images.githubusercontent.com/22801583/183285347-e6c54a35-0187-4de0-b15b-5814cbca7f67.png)
> What the dataframe looks like. Personal information blurred to avoid storing a static copy of it in this PR description.

---

On the side, the way queries are documented can be improved.

> Pre-formatted text must be indented relative to the surrounding comment text (see gob’s [doc.go](https://go.dev/src/pkg/encoding/gob/doc.go) for an example).
> 
> — https://go.dev/blog/godoc

If you indent the query, it'll have like a code block in the documentation. Currently, your other docs containing GraphQL queries look a little broken in comparison, I may clean it up later in another PR.