### PR TITLE
Docs: Clean dev guide and add Grafana toolkit to deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Options:
 | Default Repository    | true     |
 | Github Enterprise URL | false    |
 
-To create a new Access Token, navigate to [Personal Access Tokens](https://github.com/settings/tokens) and create a click "Generate new token."
+To create a new Access Token, navigate to [Personal Access Tokens](https://github.com/settings/tokens) and press **Generate new token.**
+
 ### Provisioning
+
 [It’s possible to configure data sources using config files with Grafana’s provisioning system](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).
 #### With the [prom-operator](https://github.com/prometheus-operator/prometheus-operator)
 ```yaml

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -3,7 +3,8 @@
 This is a very basic guide on how to set up your local environment, make the desired changes and see the result with a fresh Grafana Installation.
 
 ## Getting Started
-Clone this repository into your local environment. The frontend code lives in the `src` folder, alongside the [plugin.json file](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/). See [this grafana tutorial](https://grafana.com/docs/grafana/latest/developers/plugins/) to understand better how a plugin is structured and installed.
+
+Clone this repository to your local environment. The frontend code lives in the `src` folder, alongside the [plugin.json file](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/). See [this Grafana tutorial](https://grafana.com/docs/grafana/latest/developers/plugins/) to understand better how a plugin is structured and installed.
 
 Backend code, written in Go, is located in the `pkg` folder.
 
@@ -14,10 +15,12 @@ For this standard execution, you will need the following tools:
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
+- [Grafana Toolkit](https://www.npmjs.com/package/@grafana/toolkit)
 
 ## Running the development version
 
 ### Compiling the Backend
+
 If you have made any changes to any `go` files, you can use [mage](https://github.com/magefile/mage) to recompile the plugin.
 
 ```sh
@@ -25,6 +28,7 @@ mage build:linux && mage reloadPlugin
 ```
 
 ### Compiling the Frontend
+
 After you made the desired changes, you can build and test the new version of the plugin using `yarn`:
 
 ```sh
@@ -38,16 +42,18 @@ Alternatively, you can have yarn watch for changes and automatically recompile t
 yarn watch
 ```
 Now that you have a `./dist` folder, you are ready to run a fresh Grafana instance and put the new version of the datasource into [Grafana plugin folder](https://grafana.com/docs/grafana/latest/plugins/installation/).
+
 ### Docker Compose
-We provide a [Docker Compose file](/docker-compose.yml) to help you to get started. When you call up `docker-compose up` inside the project folder, it will:
+
+We provide a [Docker Compose file](/docker-compose.yml) to help you to get started. When you call up `docker compose up` inside the project folder, it will:
 
 1. Run a new instance of Grafana from the master branch and map it into port `3000`.
 1. Configure the instance to allow an unsigned version of `github-datasource` to be installed.
 1. Map the current folder contents into `/var/lib/grafana/plugins`.
 
-This is enough for you to see the Github Datasource in the datasource list at `http://localhost:3000/datasources/new`.
+This is enough for you to see the GitHub Datasource in the datasource list at `http://localhost:3000/datasources/new`.
 
-![Local Github Stats installation](./screenshots/local-plugin-install.png)
+![Local GitHub Stats installation](./screenshots/local-plugin-install.png)
 
 If you make further changes into the code, be sure to run `yarn dev` again and restart the Grafana instance.
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 var (
 	// ErrorBadDatasource is only returned when the plugin instance's type could not be asserted
-	ErrorBadDatasource = errors.New("instance from plugin context is not a Github Datasource")
+	ErrorBadDatasource = errors.New("instance from plugin context is not a GitHub Datasource")
 
 	// ErrorQueryTypeUnimplemented is returned when the client sends an unrecognized querytype
 	ErrorQueryTypeUnimplemented = errors.New("the query type provided is not implemented")

--- a/pkg/github/commits.go
+++ b/pkg/github/commits.go
@@ -51,23 +51,22 @@ func (c Commits) Frames() data.Frames {
 }
 
 // QueryListCommits is the object representation of the graphql query for retrieving a paginated list of commits for a project
-//
 //	query {
-//	  repository(name:"$name", owner:"$owner") {
-//	    object(expression: "master") {
-//	      ... on Commit {
-//	        history {
-//	          nodes {
-//	            committedDate
-//	          }
-//	          pageInfo{
-//	            hasNextPage
-//	            hasPreviousPage
-//	          }
-//	        }
-//	      }
-//	    }
-//	  }
+//		repository(name:"$name", owner:"$owner") {
+//			object(expression: "master") {
+//				... on Commit {
+//					history {
+//						nodes {
+//							committedDate
+//						}
+//						pageInfo{
+//							hasNextPage
+//							hasPreviousPage
+//						}
+//					}
+//				}
+//			}
+//		}
 //	}
 type QueryListCommits struct {
 	Repository struct {

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -13,7 +13,7 @@ type Settings struct {
 	CachingEnabled bool   `json:"cachingEnabled"`
 }
 
-// LoadSettings converts the DataSourceInLoadSettings to usable Github settings
+// LoadSettings converts the DataSourceInLoadSettings to usable GitHub settings
 func LoadSettings(settings backend.DataSourceInstanceSettings) (Settings, error) {
 	s := Settings{}
 	if err := json.Unmarshal(settings.JSONData, &s); err != nil {

--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -75,7 +75,7 @@ export class ConfigEditor extends PureComponent<ConfigEditorProps> {
               onChange={this.onSettingUpdate('accessToken', false)}
               onBlur={this.onSettingUpdate('accessToken')}
               value={secureSettings.accessToken || ''}
-              placeholder="Github Personal Access Token"
+              placeholder="GitHub Personal Access Token"
               onReset={this.onSettingReset('accessToken')}
               isConfigured={secureJsonFields!['accessToken']}
             />


### PR DESCRIPTION
Very minor PR that just does 3 things:
* Replace `docker-compose` with `docker compose` as Docker Compose v1 is now deprecated. ([More Info](https://www.docker.com/blog/announcing-compose-v2-general-availability/))
* Adds Grafana Toolkit as a requirement to develop the project.
* Minor formatting changes to **developer-guide.md**.
* Github → GitHub
* Wording/typos in README
* Make referencing text/buttons similar to Grafana tutorials, and use word "press" instead of "click" as it's device/display agnostics.