### PR TITLE
Fix incorrectly typed vulnerabilities query options

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -100,5 +100,5 @@ type MilestonesQuery struct {
 // VulnerabilityQuery is used when querying for GitHub Repository Vulnerabilities
 type VulnerabilityQuery struct {
 	Query
-	Options ListMilestonesOptions `json:"options"`
+	Options ListVulnerabilitiesOptions `json:"options"`
 }


### PR DESCRIPTION
For some reason (copy-paste?) we are using `ListMilestonesOptions` for vulnerabilities — we should be using `ListVulnerabilitiesOptions` instead.