### PR TITLE
Chore: Backend binaries are now compiled with golang 1.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## [1.4.5] - 2023-04-04
+## [1.4.5] - 2023-05-04
 
-- **Chore** - CI pipeline updated with GO 1.20.4
+- **Chore** - Backend binaries are now compiled with golang 1.20.4
 
 ## [1.4.4] - 2023-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.4.5] - 2023-04-04
+
+- **Chore** - CI pipeline updated with GO 1.20.4
+
 ## [1.4.4] - 2023-04-19
 
 - **Chore** - Updated go version to 1.20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-github-datasource",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "loads data from github issues/Pr's to Grafana",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Backend binaries are now compiled with golang 1.20.4