### PR TITLE
(projects) Increase Page limit

### DIFF
--- a/pkg/github/constants.go
+++ b/pkg/github/constants.go
@@ -1,4 +1,4 @@
 package github
 
 // PageNumberLimit is the limit on the number of pages that will be traversed
-const PageNumberLimit = 2
+const PageNumberLimit = 12

--- a/pkg/github/projects/projects.go
+++ b/pkg/github/projects/projects.go
@@ -12,8 +12,9 @@ import (
 )
 
 // PageNumberLimit is the limit on the number of pages that will be traversed
-// Setting to 10 because GH limits active issues in a project to 1_000
-const PageNumberLimit = 10
+// Setting to 10 because GH limits active issues in a project to 1_200
+// https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project
+const PageNumberLimit = 12
 
 // QueryListProjects lists all projects in a repository
 // organization(login: "grafana") {

--- a/pkg/github/projects/projects.go
+++ b/pkg/github/projects/projects.go
@@ -12,7 +12,8 @@ import (
 )
 
 // PageNumberLimit is the limit on the number of pages that will be traversed
-const PageNumberLimit = 2
+// Setting to 10 because GH limits active issues in a project to 1_000
+const PageNumberLimit = 10
 
 // QueryListProjects lists all projects in a repository
 // organization(login: "grafana") {


### PR DESCRIPTION
Increase page limit to 12 to match GitHub project issue limits

Reference documentation; https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project