### PR TITLE
issues search - allow repo to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.5.0] - 2023-09-13
+
+- **Feature** - Issues Query: Allow repo to be optional
 
 ## [1.4.7] - 2023-08-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-github-datasource",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "loads data from github issues/Pr's to Grafana",
   "private": true,
   "scripts": {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -65,7 +65,6 @@ func (c Issues) Frames() data.Frames {
 }
 
 // QuerySearchIssues is the object representation of the graphql query for retrieving a paginated list of issues using the search query
-//
 //	{
 //	  search(query: "is:issue repo:grafana/grafana opened:2020-08-19..*", type: ISSUE, first: 100) {
 //	    nodes {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -65,6 +65,7 @@ func (c Issues) Frames() data.Frames {
 }
 
 // QuerySearchIssues is the object representation of the graphql query for retrieving a paginated list of issues using the search query
+//
 //	{
 //	  search(query: "is:issue repo:grafana/grafana opened:2020-08-19..*", type: ISSUE, first: 100) {
 //	    nodes {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -65,15 +65,16 @@ func (c Issues) Frames() data.Frames {
 }
 
 // QuerySearchIssues is the object representation of the graphql query for retrieving a paginated list of issues using the search query
-// {
-//   search(query: "is:issue repo:grafana/grafana opened:2020-08-19..*", type: ISSUE, first: 100) {
-//     nodes {
-//       ... on PullRequest {
-//         id
-//         title
-//       }
-//   }
-// }
+//
+//	{
+//	  search(query: "is:issue repo:grafana/grafana opened:2020-08-19..*", type: ISSUE, first: 100) {
+//	    nodes {
+//	      ... on PullRequest {
+//	        id
+//	        title
+//	      }
+//	  }
+//	}
 type QuerySearchIssues struct {
 	Search struct {
 		Nodes []struct {
@@ -85,9 +86,15 @@ type QuerySearchIssues struct {
 
 // GetIssuesInRange lists issues in a project given a time range.
 func GetIssuesInRange(ctx context.Context, client models.Client, opts models.ListIssuesOptions, from time.Time, to time.Time) (Issues, error) {
+
+	filter := fmt.Sprintf("repo:%s/%s", opts.Owner, opts.Repository)
+	if opts.Repository == "" {
+		filter = fmt.Sprintf("owner:%s", opts.Owner)
+	}
+
 	search := []string{
 		"is:issue",
-		fmt.Sprintf("repo:%s/%s", opts.Owner, opts.Repository),
+		filter,
 		fmt.Sprintf("%s:%s..%s", opts.TimeField.String(), from.Format(time.RFC3339), to.Format(time.RFC3339)),
 	}
 


### PR DESCRIPTION
A feature request for "querying across multiple repos other than having one query per repo and then adding transformations after"

@vickyyyyyyy 