### PR TITLE
Update default branch template variable from "master" to "main"

### DIFF
--- a/src/dashboards/dashboard.json
+++ b/src/dashboards/dashboard.json
@@ -1660,8 +1660,8 @@
       {
         "current": {
           "selected": true,
-          "text": "master",
-          "value": "master"
+          "text": "main",
+          "value": "main"
         },
         "hide": 0,
         "includeAll": false,
@@ -1671,11 +1671,11 @@
         "options": [
           {
             "selected": true,
-            "text": "master",
-            "value": "master"
+            "text": "main",
+            "value": "main"
           }
         ],
-        "query": "master",
+        "query": "main",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"


### PR DESCRIPTION
Github's default name for primary branch has been changed from `master` to `main` ~1 year ago. Therefore it probably make sense to update it in dashboard.json as well. More here https://github.com/github/renaming. 