### PR TITLE
Fix datasource configuration backwards compatibility

### DIFF
--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+// this custom component is necessary because the Grafana UI <Divider /> component is no backwards compatible with Grafana < 10.1.0
+export const Divider = () => {
+  const styles = useStyles2(getStyles);
+  return <hr className={styles.horizontalDivider} />;
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    horizontalDivider: css({
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+      margin: theme.spacing(2, 0),
+      width: '100%',
+    }),
+  };
+};

--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/css';
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2, onUpdateDatasourceJsonDataOption } from '@grafana/data';
 import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
-import { Collapse, Divider, Field, Input, Label, RadioButtonGroup, SecretInput, useStyles2 } from '@grafana/ui';
+import { Collapse, Field, Input, Label, RadioButtonGroup, SecretInput, useStyles2 } from '@grafana/ui';
 import React, { ChangeEvent, useState } from 'react';
 import { selectors } from '../components/selectors';
 import { GithubDataSourceOptions, GithubSecureJsonData } from '../types';
+import { Divider } from 'components/Divider';
 
 export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<GithubDataSourceOptions, GithubSecureJsonData>;
 


### PR DESCRIPTION
when updating the configuration pages, the divider component broke backwards compatibility with any grafana version `< 10.1.0`. this pr fixes that.

**How to test:**
- run grafana in any version `< 10.1.0`
- connect go to the datasource configuration page
> if the config page loads, this fix worked.