### PR TITLE
health check updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cypress/report.json
 
 .eslintcache
 __debug_bin
+mage_output_file.go

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/github-datasource/pkg/dfutil"
 	githubclient "github.com/grafana/github-datasource/pkg/github/client"
@@ -183,10 +184,13 @@ func (d *Datasource) HandleWorkflowUsageQuery(ctx context.Context, query *models
 // CheckHealth is the health check for GitHub
 func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	_, err := GetAllRepositories(ctx, d.client, models.ListRepositoriesOptions{
-		Owner: "grafana",
+		Owner:      "grafana",
+		Repository: "github-datasource",
 	})
-
 	if err != nil {
+		if strings.Contains(err.Error(), "401 Unauthorized") {
+			return newHealthResult(backend.HealthStatusError, "401 Unauthorized. check your API key/Access token")
+		}
 		return newHealthResult(backend.HealthStatusError, "Health check failed")
 	}
 


### PR DESCRIPTION
* currently health check retrieves list of all repos within grafana org. This requires lots of pagination and slow. Instead this PR filters the number of repos to `github-datasource`. with this no changes in existing behaviour but this will bit faster.
* also when invalid/empty credentials entered, we currently show "health check failed". Instead this PR will show little more context. ( underlying library abstracts the error https://github.com/shurcooL/graphql/blob/ed46e5a4646634fc16cb07c3b8db389542cc8847/graphql.go#L79 . also we don't want to show this error message as retrieved for security reasons )