### PR TITLE
more query types added to variables editor

### DIFF
--- a/src/views/VariableQueryEditor.tsx
+++ b/src/views/VariableQueryEditor.tsx
@@ -4,7 +4,7 @@ import { InlineField } from '@grafana/ui';
 
 import QueryEditor from './QueryEditor';
 import { GithubDataSource } from '../DataSource';
-import { GitHubVariableQuery, DefaultQueryType, QueryType } from '../types';
+import { GitHubVariableQuery, DefaultQueryType } from '../types';
 import FieldSelect from '../components/FieldSelect';
 import { isValid } from '../validation';
 
@@ -39,15 +39,6 @@ const VariableQueryEditor = (props: Props) => {
           )
         }
         onRunQuery={() => {}}
-        queryTypes={[
-          QueryType.Repositories,
-          QueryType.Contributors,
-          QueryType.Tags,
-          QueryType.Releases,
-          QueryType.Labels,
-          QueryType.Milestones,
-          QueryType.Projects,
-        ]}
       />
       <InlineField labelWidth={20} label="Field Value" tooltip="This field determines the value used for the variable">
         <FieldSelect


### PR DESCRIPTION
In variables editor, list of supported query types is hardcoded and out of sync with query editor. This PR makes the query types consistent. 

( By removing the queryTypes argument in the VariablesEditor, this will fallback to [defaults set in the QueryEditor](https://github.com/grafana/github-datasource/blob/0db88ecb57e2e7f530c610018f8a633a5db7f16f/src/views/QueryEditor.tsx#L136) )

<img width="938" alt="image" src="https://github.com/grafana/github-datasource/assets/153843/cabba857-64dc-4de8-99f7-b3f3fb3160ca">
