### PR TITLE
return commit-message for commits

### DIFF
--- a/pkg/github/commits.go
+++ b/pkg/github/commits.go
@@ -33,6 +33,7 @@ func (c Commits) Frames() data.Frames {
 		data.NewField("author_company", nil, []string{}),
 		data.NewField("committed_at", nil, []time.Time{}),
 		data.NewField("pushed_at", nil, []time.Time{}),
+		data.NewField("message", nil, []string{}),
 	)
 
 	for _, v := range c {
@@ -44,6 +45,7 @@ func (c Commits) Frames() data.Frames {
 			v.Author.User.Company,
 			v.CommittedDate.Time,
 			v.PushedDate.Time,
+			string(v.Message),
 		)
 	}
 

--- a/pkg/github/testdata/commits.golden.jsonc
+++ b/pkg/github/testdata/commits.golden.jsonc
@@ -2,15 +2,15 @@
 //  
 //  Frame[0] 
 //  Name: commits
-//  Dimensions: 7 Fields by 2 Rows
-//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+
-//  | Name: id       | Name: author    | Name: author_login | Name: author_email | Name: author_company | Name: committed_at              | Name: pushed_at                 |
-//  | Labels:        | Labels:         | Labels:            | Labels:            | Labels:              | Labels:                         | Labels:                         |
-//  | Type: []string | Type: []string  | Type: []string     | Type: []string     | Type: []string       | Type: []time.Time               | Type: []time.Time               |
-//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+
-//  |                | firstCommitter  | firstCommitter     | first@example.com  | ACME Corp            | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:23:56 +0000 +0000 |
-//  |                | secondCommitter | secondCommitter    | second@example.com | ACME Corp            | 2020-08-25 17:21:56 +0000 +0000 | 2020-08-25 18:21:56 +0000 +0000 |
-//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+
+//  Dimensions: 8 Fields by 2 Rows
+//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+----------------+
+//  | Name: id       | Name: author    | Name: author_login | Name: author_email | Name: author_company | Name: committed_at              | Name: pushed_at                 | Name: message  |
+//  | Labels:        | Labels:         | Labels:            | Labels:            | Labels:              | Labels:                         | Labels:                         | Labels:        |
+//  | Type: []string | Type: []string  | Type: []string     | Type: []string     | Type: []string       | Type: []time.Time               | Type: []time.Time               | Type: []string |
+//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+----------------+
+//  |                | firstCommitter  | firstCommitter     | first@example.com  | ACME Corp            | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 16:23:56 +0000 +0000 | commit #1      |
+//  |                | secondCommitter | secondCommitter    | second@example.com | ACME Corp            | 2020-08-25 17:21:56 +0000 +0000 | 2020-08-25 18:21:56 +0000 +0000 | commit #2      |
+//  +----------------+-----------------+--------------------+--------------------+----------------------+---------------------------------+---------------------------------+----------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -69,6 +69,13 @@
             "typeInfo": {
               "frame": "time.Time"
             }
+          },
+          {
+            "name": "message",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
           }
         ]
       },
@@ -101,6 +108,10 @@
           [
             1598372636000,
             1598379716000
+          ],
+          [
+            "commit #1",
+            "commit #2"
           ]
         ]
       }


### PR DESCRIPTION
(fixes https://github.com/grafana/github-datasource/issues/140)

shows the commit-message for commits.

how to test:
- list commits for a repository
- you should see a column `message` with the commit-message