### PR TITLE
Templating: Fix error when response has data with empty array

### DIFF
--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,37 +1,46 @@
-import { DataQueryResponse, DataSourceInstanceSettings, toDataFrame } from "@grafana/data";
-import { GitHubVariableQuery } from "types";
+import { DataQueryResponse, DataSourceInstanceSettings, toDataFrame } from '@grafana/data';
+import { GitHubVariableQuery } from 'types';
 import { of } from 'rxjs';
-import { GithubDataSource } from "DataSource";
+import { GithubDataSource } from 'DataSource';
 
 describe('DataSource', () => {
   describe('metricFindQuery', () => {
     it('should return empty array if data in response is empty array', async () => {
       const ds = new GithubDataSource({} as DataSourceInstanceSettings);
-      const query = {} as GitHubVariableQuery
+      const query = {} as GitHubVariableQuery;
 
-      jest.spyOn(ds, 'query').mockReturnValue(of({data: []}))
-      const res = await ds.metricFindQuery(query, {})
-      expect(res).toEqual([])
+      jest.spyOn(ds, 'query').mockReturnValue(of({ data: [] }));
+      const res = await ds.metricFindQuery(query, {});
+      expect(res).toEqual([]);
     });
 
     it('should return empty array if no data in response', async () => {
       const ds = new GithubDataSource({} as DataSourceInstanceSettings);
-      const query = {} as GitHubVariableQuery
+      const query = {} as GitHubVariableQuery;
 
-      jest.spyOn(ds, 'query').mockReturnValue(of({} as DataQueryResponse))
-      const res = await ds.metricFindQuery(query, {})
-      expect(res).toEqual([])
+      jest.spyOn(ds, 'query').mockReturnValue(of({} as DataQueryResponse));
+      const res = await ds.metricFindQuery(query, {});
+      expect(res).toEqual([]);
     });
 
     it('should return array with values if response has data', async () => {
       const ds = new GithubDataSource({} as DataSourceInstanceSettings);
-      const query = {key: 'test', field: 'test'} as GitHubVariableQuery
+      const query = { key: 'test', field: 'test' } as GitHubVariableQuery;
 
-      jest.spyOn(ds, 'query').mockReturnValue(of({data: [toDataFrame({
-        fields: [{name: 'test', values: ['value1', 'value2']}]
-      })]} as DataQueryResponse))
-      const res = await ds.metricFindQuery(query, {})
-      expect(res).toEqual([{value: 'value1', text: 'value1'}, {value: 'value2', text: 'value2'}])
+      jest.spyOn(ds, 'query').mockReturnValue(
+        of({
+          data: [
+            toDataFrame({
+              fields: [{ name: 'test', values: ['value1', 'value2'] }],
+            }),
+          ],
+        } as DataQueryResponse)
+      );
+      const res = await ds.metricFindQuery(query, {});
+      expect(res).toEqual([
+        { value: 'value1', text: 'value1' },
+        { value: 'value2', text: 'value2' },
+      ]);
     });
-    })
-  }); 
+  });
+});

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,0 +1,17 @@
+import { DataSourceInstanceSettings } from "@grafana/data";
+import { GitHubVariableQuery } from "types";
+import { of } from 'rxjs';
+import { GithubDataSource } from "DataSource";
+
+describe('DataSource', () => {
+  describe('metricFindQuery', () => {
+    it('should not throw an error when data in response is empty array', async () => {
+      const ds = new GithubDataSource({} as DataSourceInstanceSettings);
+      const query = {} as GitHubVariableQuery
+
+      jest.spyOn(ds, 'query').mockReturnValue(of({data: []}))
+      const res = await ds.metricFindQuery(query, {})
+      expect(res).toEqual([])
+    });
+    })
+  }); 

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -5,7 +5,7 @@ import { GithubDataSource } from "DataSource";
 
 describe('DataSource', () => {
   describe('metricFindQuery', () => {
-    it('should not throw an error when data in response is empty array', async () => {
+    it('should return empty array if data in response is empty array', async () => {
       const ds = new GithubDataSource({} as DataSourceInstanceSettings);
       const query = {} as GitHubVariableQuery
 

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings } from "@grafana/data";
+import { DataQueryResponse, DataSourceInstanceSettings, toDataFrame } from "@grafana/data";
 import { GitHubVariableQuery } from "types";
 import { of } from 'rxjs';
 import { GithubDataSource } from "DataSource";
@@ -12,6 +12,26 @@ describe('DataSource', () => {
       jest.spyOn(ds, 'query').mockReturnValue(of({data: []}))
       const res = await ds.metricFindQuery(query, {})
       expect(res).toEqual([])
+    });
+
+    it('should return empty array if no data in response', async () => {
+      const ds = new GithubDataSource({} as DataSourceInstanceSettings);
+      const query = {} as GitHubVariableQuery
+
+      jest.spyOn(ds, 'query').mockReturnValue(of({} as DataQueryResponse))
+      const res = await ds.metricFindQuery(query, {})
+      expect(res).toEqual([])
+    });
+
+    it('should return array with values if response has data', async () => {
+      const ds = new GithubDataSource({} as DataSourceInstanceSettings);
+      const query = {key: 'test', field: 'test'} as GitHubVariableQuery
+
+      jest.spyOn(ds, 'query').mockReturnValue(of({data: [toDataFrame({
+        fields: [{name: 'test', values: ['value1', 'value2']}]
+      })]} as DataQueryResponse))
+      const res = await ds.metricFindQuery(query, {})
+      expect(res).toEqual([{value: 'value1', text: 'value1'}, {value: 'value2', text: 'value2'}])
     });
     })
   }); 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -120,7 +120,6 @@ export class GithubDataSource extends DataSourceWithBackend<GitHubQuery, GithubD
       const view = new DataFrameView(res.data[0] as DataFrame);
       return view.map((item) => {
         const value = item[query.key || ''] || item[query.field || 'name'];
-        console.log(value);
         return {
           value,
           text: item[query.field || 'name'],

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -120,7 +120,7 @@ export class GithubDataSource extends DataSourceWithBackend<GitHubQuery, GithubD
       const view = new DataFrameView(res.data[0] as DataFrame);
       return view.map((item) => {
         const value = item[query.key || ''] || item[query.field || 'name'];
-        console.log(value)
+        console.log(value);
         return {
           value,
           text: item[query.field || 'name'],

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -120,6 +120,7 @@ export class GithubDataSource extends DataSourceWithBackend<GitHubQuery, GithubD
       const view = new DataFrameView(res.data[0] as DataFrame);
       return view.map((item) => {
         const value = item[query.key || ''] || item[query.field || 'name'];
+        console.log(value)
         return {
           value,
           text: item[query.field || 'name'],

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -113,8 +113,8 @@ export class GithubDataSource extends DataSourceWithBackend<GitHubQuery, GithubD
       rangeRaw: options.rangeRaw,
     } as DataQueryRequest;
     try {
-      let res = await this.query(request).toPromise();
-      if (!res || !res.data || res.data.length < 0) {
+      const res = await this.query(request).toPromise();
+      if (!res || !res.data || res.data.length <= 0) {
         return [];
       }
       const view = new DataFrameView(res.data[0] as DataFrame);


### PR DESCRIPTION
This PR addresses an issue where users encountered an error while creating template variables if the response contained an empty data array. The code has been updated to handle such cases.

Fixed (no error): 

https://github.com/grafana/github-datasource/assets/30407135/af16218f-185f-429c-92b0-87bb582c094a

Broken (with error in the UI):

https://github.com/grafana/github-datasource/assets/30407135/f80de723-8654-475f-8337-7c566998012d