### PR TITLE
Workflows: Fix per page limit to 100 as it is max supported value

### DIFF
--- a/pkg/github/workflows.go
+++ b/pkg/github/workflows.go
@@ -56,8 +56,9 @@ func GetWorkflows(ctx context.Context, client models.Client, opts models.ListWor
 	}
 
 	// Fetch this many workflows per page because this API endpoint does not allow filtering by time.
-	// It's unlikely a repository will have more workflows than this.
-	data, _, err := client.ListWorkflows(ctx, opts.Owner, opts.Repository, &github.ListOptions{Page: 0, PerPage: 1000})
+	// 100 is the maximum number of workflows that can be retrieved per request as specified in the GitHub API documentation.
+	// Also, it's unlikely a repository will have more workflows than this.
+	data, _, err := client.ListWorkflows(ctx, opts.Owner, opts.Repository, &github.ListOptions{Page: 1, PerPage: 100})
 	if err != nil {
 		return nil, fmt.Errorf("listing workflows: opts=%+v %w", opts, err)
 	}


### PR DESCRIPTION
Updates `per_page` param in workflow queries to 100 as that is max supported value by API: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#query-parameters
<img width="1086" alt="image" src="https://github.com/grafana/github-datasource/assets/30407135/b56b526b-8376-41fd-920b-98d1b5e46450">
