### PR TITLE
Fix: Remove query input in Vulnerabilities as not used and no API to support it

### DIFF
--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -127,7 +127,6 @@ func (d *Datasource) HandleVulnerabilitiesQuery(ctx context.Context, query *mode
 	opt := models.ListVulnerabilitiesOptions{
 		Repository: query.Repository,
 		Owner:      query.Owner,
-		Query:      query.Options.Query,
 	}
 
 	return GetAllVulnerabilities(ctx, d.client, opt)

--- a/pkg/github/vulnerabilities.go
+++ b/pkg/github/vulnerabilities.go
@@ -10,19 +10,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-// QueryListVulnerabilities lists all labels in a repository
-//
-//	{
-//	  repository(name: "grafana", owner: "grafana") {
-//	    labels(first: 100) {
-//	      nodes {
-//	        color
-//	        description
-//	        name
-//	      }
-//	    }
-//	  }
-//	}
+// QueryListVulnerabilities lists all vulnerability alerts in a repository
 //
 //	{
 //	    repository(name: "repo-name", owner: "repo-owner") {

--- a/pkg/github/workflows.go
+++ b/pkg/github/workflows.go
@@ -56,8 +56,9 @@ func GetWorkflows(ctx context.Context, client models.Client, opts models.ListWor
 	}
 
 	// Fetch this many workflows per page because this API endpoint does not allow filtering by time.
-	// It's unlikely a repository will have more workflows than this.
-	data, _, err := client.ListWorkflows(ctx, opts.Owner, opts.Repository, &github.ListOptions{Page: 0, PerPage: 1000})
+	// 100 is the maximum number of workflows that can be retrieved per request as specified in the GitHub API documentation.
+	// Also, it's unlikely a repository will have more workflows than this.
+	data, _, err := client.ListWorkflows(ctx, opts.Owner, opts.Repository, &github.ListOptions{Page: 1, PerPage: 100})
 	if err != nil {
 		return nil, fmt.Errorf("listing workflows: opts=%+v %w", opts, err)
 	}

--- a/pkg/models/vulnerabilities.go
+++ b/pkg/models/vulnerabilities.go
@@ -7,7 +7,4 @@ type ListVulnerabilitiesOptions struct {
 
 	// Owner is the owner of the repository (ex: grafana)
 	Owner string `json:"owner"`
-
-	// Query searches x by name and description
-	Query string `json:"query"`
 }

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -78,7 +78,7 @@ const queryEditors: {
   },
   [QueryType.Vulnerabilities]: {
     component: (props: Props, onChange: (val: any) => void) => (
-      <QueryEditorVulnerabilities {...(props.query.options || {})} onChange={onChange} />
+      <QueryEditorVulnerabilities {...(props.query.options || {})} />
     ),
   },
   [QueryType.Projects]: {

--- a/src/views/QueryEditorVulnerabilities.tsx
+++ b/src/views/QueryEditorVulnerabilities.tsx
@@ -1,27 +1,4 @@
-import React, { useState } from 'react';
-import { Input, InlineField } from '@grafana/ui';
+import React from 'react';
 
-import { LabelsOptions } from '../types';
-import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
-
-interface Props extends LabelsOptions {
-  onChange: (value: LabelsOptions) => void;
-}
-
-const QueryEditorVulnerabilities = (props: Props) => {
-  const [query, setQuery] = useState<string>(props.query || '');
-  return (
-    <>
-      <InlineField labelWidth={LeftColumnWidth * 2} label="Query (optional)">
-        <Input
-          width={RightColumnWidth}
-          value={query}
-          onChange={(el) => setQuery(el.currentTarget.value)}
-          onBlur={(el) => props.onChange({ ...props, query: el.currentTarget.value })}
-        />
-      </InlineField>
-    </>
-  );
-};
-
+const QueryEditorVulnerabilities = () => <></>;
 export default QueryEditorVulnerabilities;


### PR DESCRIPTION
While investigating https://github.com/grafana/github-datasource/issues/304 I noticed that:
1. Query created in query field is not used in executed graphQL query to Github
2. The `vulnerabilityAlerts` query  that we are creating doesn't support `query` parameter (for example some apis support it - such as `milestones` or  `labels`) https://docs.github.com/en/graphql/reference/objects. So even if we wanted to implement it, github would need to support it first. Also I have checked `securityVulnerabilities ` query type, but  it wasn't providing `query` param in any of these (also I am not sure if  `securityVulnerabilities` and `vulnerabilityAlerts` are the same thing, but both don't have `query` so I didn't look further). And lastly I've checked `serach`, but it does not have vulnerabilities type.

I have checked [github reqests/questions on community site](https://github.com/orgs/community/discussions?discussions_q=is%3Aopen+vulnerabilityAlerts+) and it seems that there is none related to adding `query` param. So it would be worth to probably start there, but I'll leave this for users requesting this feature to ask there.

So this PR removes `query` input and logic as it isn't used anywhere. 

<img width="797" alt="image" src="https://github.com/grafana/github-datasource/assets/30407135/e4c3de6d-c8c7-463a-9d55-b65cf94c0708">


<img width="1136" alt="image" src="https://github.com/grafana/github-datasource/assets/30407135/6c392f6d-9ee3-4bc5-a180-055e015b7636">

Fixes https://github.com/grafana/github-datasource/issues/304