### PR TITLE
Instrumentation: Make context.Canceled error downstream and fix logging to correct level

### DIFF
--- a/pkg/dfutil/framer.go
+++ b/pkg/dfutil/framer.go
@@ -23,7 +23,7 @@ func FrameResponse(f Framer) backend.DataResponse {
 func FrameResponseWithError(f Framer, err error) backend.DataResponse {
 	if err != nil {
 		res := errorsource.Response(err)
-		backend.Logger.Error("Error response", "errorsource", res.ErrorSource, "error", res.Error)
+		backend.Logger.Debug("Error response", "errorsource", res.ErrorSource, "error", res.Error)
 		return res
 	}
 

--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -1,6 +1,7 @@
 package githubclient
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strconv"
@@ -21,6 +22,10 @@ func addErrorSourceToError(err error, resp *googlegithub.Response) error {
 	}
 
 	if errors.Is(err, syscall.ECONNREFUSED) {
+		return errorsource.DownstreamError(err, false)
+	}
+
+	if errors.Is(err, context.Canceled) {	
 		return errorsource.DownstreamError(err, false)
 	}
 	// Unfortunately graphql library that is used is not returning original error from the client.

--- a/pkg/github/client/errorsourcehandling_test.go
+++ b/pkg/github/client/errorsourcehandling_test.go
@@ -1,6 +1,7 @@
 package githubclient
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"syscall"
@@ -48,6 +49,12 @@ func TestAddErrorSourceToError(t *testing.T) {
 			err:      nil,
 			resp:     &googlegithub.Response{Response: &http.Response{StatusCode: 200}},
 			expected: nil,
+		},
+		{
+			name:     "context canceled error",
+			err:      context.Canceled,
+			resp:     nil,
+			expected: errorsource.DownstreamError( context.Canceled, false),
 		},
 	}
 


### PR DESCRIPTION
This PR improves internal data source instumentation. It
- Makes context.Canceled errors downstream so internally when we log them, they have correct source
- Changes logging of error response to `debug` as this is not error and is correct behavior. 

We don't need to release this right away as it does not influence important metrics that we use for alerts. 