### PR TITLE
Fix e2e test with 10.1.x Grafana version

### DIFF
--- a/tests/ConfigEditor.spec.ts
+++ b/tests/ConfigEditor.spec.ts
@@ -14,7 +14,7 @@ test('ConfigEditor smoke test', async ({ createDataSourceConfigPage, page, selec
   });
   await configPage.getByGrafanaSelector(components.ConfigEditor.AccessToken).fill('my-access-token');
   // TODO: Move this logic to plugin-e2e
-  if (semver.lt(grafanaVersion, '10.0.0')) {
+  if (semver.lt(grafanaVersion, '10.2.0')) {
     await page.getByText('Enterprise', { exact: true }).click();
   } else {
     await page.getByRole('radio', { name: 'Enterprise' }).check();

--- a/tests/ConfigEditor.spec.ts
+++ b/tests/ConfigEditor.spec.ts
@@ -14,7 +14,7 @@ test('ConfigEditor smoke test', async ({ createDataSourceConfigPage, page, selec
   });
   await configPage.getByGrafanaSelector(components.ConfigEditor.AccessToken).fill('my-access-token');
   // TODO: Move this logic to plugin-e2e
-  if (semver.lt(grafanaVersion, '10.1.0')) {
+  if (semver.lt(grafanaVersion, '10.0.0')) {
     await page.getByText('Enterprise', { exact: true }).click();
   } else {
     await page.getByRole('radio', { name: 'Enterprise' }).check();


### PR DESCRIPTION
This PR fixes e2e test for Grafana version 10.1. Previously, the e2e test was run with Grafana version 10.0, which was passing. However, after the recent Grafana release, the version used in e2e tests was updated to 10.1  and the test started to fail. This PR does not change any actual source code - it only updates the e2e test logic and modifies how the enterprise button is clicked for version 10.1 to be the same as for version 10.0.