### PR TITLE
Packages: Hide package types that are throwing error

### DIFF
--- a/src/views/QueryEditorPackages.tsx
+++ b/src/views/QueryEditorPackages.tsx
@@ -54,7 +54,9 @@ const QueryEditorPackages = (props: Props) => {
       }
     }
     return packageTypeOptions;
-  }, [props.packageType]);
+    // We want to run this only once when component is mounted and not every time packageType is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/src/views/QueryEditorPackages.tsx
+++ b/src/views/QueryEditorPackages.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Input, Select, InlineField } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
@@ -10,14 +10,7 @@ interface Props extends PackagesOptions {
   onChange: (value: PackagesOptions) => void;
 }
 
-export const DefaultPackageType = PackageType.NPM;
-
-const packageTypeOptions: Array<SelectableValue<string>> = Object.keys(PackageType).map((v) => {
-  return {
-    label: v.replace('/_/gi', ' '),
-    value: v,
-  };
-});
+export const DefaultPackageType = PackageType.DOCKER;
 
 const QueryEditorPackages = (props: Props) => {
   const [names, setNames] = useState<string>(props.names || '');
@@ -31,6 +24,37 @@ const QueryEditorPackages = (props: Props) => {
       });
     }
   }, [props]);
+
+  const packageTypeOptions = useMemo(() => {
+    // @TODO: These package types are not supported through GraphQL endpoint that we are using in our queries.
+    // We should remove them from the list of options, but for now we will just ignore them
+    // and not show them in the dropdown, if they have not been selected before.
+    // Not sure if they ever been supported.
+    const notSupportedTroughGraphQL: string[] = [PackageType.NPM, PackageType.RUBYGEMS, PackageType.NUGET];
+    const packageTypeOptions: SelectableValue[] = Object.values(PackageType)
+      .filter((packageType) => {
+        // Filter out package types that are not supported through GraphQL
+        return !notSupportedTroughGraphQL.includes(packageType);
+      })
+      .map((v) => {
+        return {
+          label: v.replace('/_/gi', ' '),
+          value: v,
+        };
+      });
+
+    // If user has selected a package type that is not in the list of options, add it to the list
+    if (props.packageType) {
+      const selectedPackageType = packageTypeOptions.find((opt: SelectableValue) => opt.value === props.packageType);
+      if (!selectedPackageType) {
+        packageTypeOptions.push({
+          label: props.packageType.replace('/_/gi', ' '),
+          value: props.packageType,
+        });
+      }
+    }
+    return packageTypeOptions;
+  }, [props.packageType]);
 
   return (
     <>


### PR DESCRIPTION
This PR removes following package types from the dropdown, as they all throw `XXX registry is not supported by GraphQL APIs.` In a case where user had previously selected one of the package types and have it saved in a query, we are going to keep it available. 
<img width="925" alt="image" src="https://github.com/user-attachments/assets/a3778967-874a-4b73-a7ba-493f74ac376c">
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/40065bc6-7575-44ca-92c8-443609eeceb5">
<img width="900" alt="image" src="https://github.com/user-attachments/assets/3828f6d9-518d-4b73-a6e7-ff2ebbf30e05">


Manual test: 
1. It shows that leftover package types are not throwing errors
2. It shows that if user had NPM (or other) package ty[e selected before, it will be still available in the dropdown

https://github.com/user-attachments/assets/70829d74-ee35-41d6-a946-5f089eae18b9

