### PR TITLE
Mark permission issues as downstream

### DIFF
--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -21,6 +21,7 @@ var (
 		"Your token has not been granted the required scopes to execute this query",
 		"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.",
 		"API rate limit exceeded",
+		"Resource not accessible by integration",
 	}
 )
 

--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -21,7 +21,7 @@ var (
 		"Your token has not been granted the required scopes to execute this query",
 		"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.",
 		"API rate limit exceeded",
-		"Resource not accessible by integration",
+		"Resource not accessible by integration", // issue with incorrectly set permissions for token/app
 	}
 )
 

--- a/pkg/github/client/errorsourcehandling_test.go
+++ b/pkg/github/client/errorsourcehandling_test.go
@@ -74,7 +74,7 @@ func TestAddErrorSourceToError(t *testing.T) {
 			resp: nil,
 			expected: errorsource.DownstreamError(errors.New("API rate limit exceeded for ID 1"), false),
 		},
-				{
+		{
 			name: "permission error message",
 			err: errors.New("Resource not accessible by integration"),
 			resp: nil,

--- a/pkg/github/client/errorsourcehandling_test.go
+++ b/pkg/github/client/errorsourcehandling_test.go
@@ -74,6 +74,12 @@ func TestAddErrorSourceToError(t *testing.T) {
 			resp: nil,
 			expected: errorsource.DownstreamError(errors.New("API rate limit exceeded for ID 1"), false),
 		},
+				{
+			name: "permission error message",
+			err: errors.New("Resource not accessible by integration"),
+			resp: nil,
+			expected: errorsource.DownstreamError(errors.New("Resource not accessible by integration"), false),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/grafana/data-sources/issues/212. If users set incorrect permissions, they can get "Resource not accessible by integration" error. This should be marked as downstream. 

Fixes https://github.com/grafana/data-sources/issues/212