### PR TITLE
query types and constants

### DIFF
--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -1,7 +1,7 @@
 import { DataQueryResponse, DataSourceInstanceSettings, toDataFrame } from '@grafana/data';
-import { GitHubVariableQuery } from 'types';
 import { of } from 'rxjs';
 import { GitHubDataSource } from 'DataSource';
+import type { GitHubVariableQuery } from 'types/query';
 
 describe('DataSource', () => {
   describe('metricFindQuery', () => {

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -16,7 +16,7 @@ import { getAnnotationsFromFrame } from 'common/annotationsFromDataFrame';
 import { prepareAnnotation } from 'migrations';
 import { Observable } from 'rxjs';
 import { trackRequest } from 'tracking';
-import type { GitHubQuery, GitHubVariableQuery } from './types';
+import type { GitHubQuery, GitHubVariableQuery } from './types/query';
 import type { GitHubDataSourceOptions } from './types/config';
 
 export class GitHubDataSource extends DataSourceWithBackend<GitHubQuery, GitHubDataSourceOptions> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,55 @@
+export enum QueryType {
+  Commits = 'Commits',
+  Issues = 'Issues',
+  Contributors = 'Contributors',
+  Tags = 'Tags',
+  Releases = 'Releases',
+  Pull_Requests = 'Pull_Requests',
+  Labels = 'Labels',
+  Repositories = 'Repositories',
+  Organizations = 'Organizations',
+  GraphQL = 'GraphQL',
+  Milestones = 'Milestones',
+  Packages = 'Packages',
+  Vulnerabilities = 'Vulnerabilities',
+  Projects = 'Projects',
+  ProjectItems = 'ProjectItems',
+  Stargazers = 'Stargazers',
+  Workflows = 'Workflows',
+  Workflow_Usage = 'Workflow_Usage',
+}
+
+export const DefaultQueryType = QueryType.Issues;
+
+export enum PackageType {
+  NPM = 'NPM',
+  RUBYGEMS = 'RUBYGEMS',
+  MAVEN = 'MAVEN',
+  DOCKER = 'DOCKER',
+  DEBIAN = 'DEBIAN',
+  NUGET = 'NUGET',
+  PYPI = 'PYPI',
+}
+
+export enum PullRequestTimeField {
+  ClosedAt,
+  CreatedAt,
+  MergedAt,
+  None,
+}
+
+export enum IssueTimeField {
+  CreatedAt,
+  ClosedAt,
+  UpdatedAt,
+}
+
+export enum WorkflowsTimeField {
+  CreatedAt,
+  UpdatedAt,
+}
+
+export enum ProjectQueryType {
+  ORG = 0,
+  USER = 1,
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import { GitHubDataSource } from './DataSource';
 import ConfigEditor from './views/ConfigEditor';
 import QueryEditor from './views/QueryEditor';
 import VariableQueryEditor from './views/VariableQueryEditor';
-import type { GitHubQuery } from './types';
+import type { GitHubQuery } from './types/query';
 import type { GitHubDataSourceOptions, GitHubSecureJsonData } from './types/config';
 
 export const plugin = new DataSourcePlugin<

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,6 +1,7 @@
 import { CoreApp, DataQueryRequest } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { GitHubQuery, IssueTimeField, PullRequestTimeField, WorkflowsTimeField } from 'types';
+import { IssueTimeField, PullRequestTimeField, WorkflowsTimeField } from './constants';
+import type { GitHubQuery } from 'types/query';
 
 export const trackRequest = (request: DataQueryRequest<GitHubQuery>) => {
   if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,5 +1,25 @@
+import { PullRequestTimeField, IssueTimeField, WorkflowsTimeField, PackageType, ProjectQueryType } from '../constants';
 import type { DataQuery } from '@grafana/schema';
 import type { Filter } from 'components/Filters';
+
+export interface RepositoryOptions {
+  repository?: string;
+  owner?: string;
+}
+
+export interface GitHubQuery extends Indexable, DataQuery, RepositoryOptions {
+  options?:
+    | PullRequestsOptions
+    | ReleasesOptions
+    | LabelsOptions
+    | TagsOptions
+    | CommitsOptions
+    | IssuesOptions
+    | ContributorsOptions
+    | ProjectsOptions
+    | WorkflowsOptions
+    | WorkflowUsageOptions;
+}
 
 export interface Label {
   color: string;
@@ -7,66 +27,14 @@ export interface Label {
   name: string;
 }
 
-export interface RepositoryOptions {
-  repository?: string;
-  owner?: string;
-}
-
-export enum QueryType {
-  Commits = 'Commits',
-  Issues = 'Issues',
-  Contributors = 'Contributors',
-  Tags = 'Tags',
-  Releases = 'Releases',
-  Pull_Requests = 'Pull_Requests',
-  Labels = 'Labels',
-  Repositories = 'Repositories',
-  Organizations = 'Organizations',
-  GraphQL = 'GraphQL',
-  Milestones = 'Milestones',
-  Packages = 'Packages',
-  Vulnerabilities = 'Vulnerabilities',
-  Projects = 'Projects',
-  ProjectItems = 'ProjectItems',
-  Stargazers = 'Stargazers',
-  Workflows = 'Workflows',
-  Workflow_Usage = 'Workflow_Usage',
-}
-
-export enum PackageType {
-  NPM = 'NPM',
-  RUBYGEMS = 'RUBYGEMS',
-  MAVEN = 'MAVEN',
-  DOCKER = 'DOCKER',
-  DEBIAN = 'DEBIAN',
-  NUGET = 'NUGET',
-  PYPI = 'PYPI',
-}
-
-export enum PullRequestTimeField {
-  ClosedAt,
-  CreatedAt,
-  MergedAt,
-  None,
-}
-
-export enum IssueTimeField {
-  CreatedAt,
-  ClosedAt,
-  UpdatedAt,
-}
-
-export enum WorkflowsTimeField {
-  CreatedAt,
-  UpdatedAt,
-}
-
 export interface Indexable {
   [index: string]: any;
 }
 
 export interface ReleasesOptions extends Indexable {}
+
 export interface TagsOptions extends Indexable {}
+
 export interface PullRequestsOptions extends Indexable {
   timeField?: PullRequestTimeField;
   query?: string;
@@ -115,25 +83,6 @@ export interface ProjectsOptions extends Indexable {
   filters?: Filter[];
 }
 
-export enum ProjectQueryType {
-  ORG = 0,
-  USER = 1,
-}
-
-export interface GitHubQuery extends Indexable, DataQuery, RepositoryOptions {
-  options?:
-    | PullRequestsOptions
-    | ReleasesOptions
-    | LabelsOptions
-    | TagsOptions
-    | CommitsOptions
-    | IssuesOptions
-    | ContributorsOptions
-    | ProjectsOptions
-    | WorkflowsOptions
-    | WorkflowUsageOptions;
-}
-
 export interface GitHubVariableQuery extends GitHubQuery {
   key?: string;
   field?: string;
@@ -142,5 +91,3 @@ export interface GitHubVariableQuery extends GitHubQuery {
 export interface GitHubAnnotationQuery extends GitHubVariableQuery {
   timeField?: string;
 }
-
-export const DefaultQueryType = QueryType.Issues;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
-import { GitHubQuery, ProjectQueryType, QueryType } from './types';
+import { ProjectQueryType, QueryType } from './constants';
+import type { GitHubQuery } from './types/query';
 
 export const isValid = (query: GitHubQuery): boolean => {
   if (query.queryType === QueryType.Repositories) {

--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -1,5 +1,5 @@
 import { replaceVariables } from './variables';
-import { GitHubQuery } from './types';
+import type { GitHubQuery } from './types/query';
 
 describe('variables', () => {
   it('should not interpolate refId', () => {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,6 +1,6 @@
-import { GitHubQuery } from './types';
 import { TemplateSrv } from '@grafana/runtime';
 import { ScopedVars } from '@grafana/data';
+import type { GitHubQuery } from './types/query';
 
 export const replaceVariable = (
   t: TemplateSrv,

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -20,7 +20,8 @@ import QueryEditorVulnerabilities from './QueryEditorVulnerabilities';
 import QueryEditorProjects from './QueryEditorProjects';
 import QueryEditorWorkflows from './QueryEditorWorkflows';
 import QueryEditorWorkflowUsage from './QueryEditorWorkflowUsage';
-import { type GitHubQuery, QueryType, DefaultQueryType } from '../types';
+import { QueryType, DefaultQueryType } from '../constants';
+import type { GitHubQuery } from '../types/query';
 import type { GitHubDataSourceOptions } from '../types/config';
 
 interface Props extends QueryEditorProps<GitHubDataSource, GitHubQuery, GitHubDataSourceOptions> {

--- a/src/views/QueryEditorCommits.tsx
+++ b/src/views/QueryEditorCommits.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { Input, InlineField } from '@grafana/ui';
-
-import { CommitsOptions } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
 import { components } from 'components/selectors';
+import type { CommitsOptions } from '../types/query';
 
 interface Props extends CommitsOptions {
   onChange: (value: CommitsOptions) => void;

--- a/src/views/QueryEditorContributors.tsx
+++ b/src/views/QueryEditorContributors.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Input, InlineField } from '@grafana/ui';
-
-import { ContributorsOptions } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import type { ContributorsOptions } from '../types/query';
 
 interface Props extends ContributorsOptions {
   onChange: (value: ContributorsOptions) => void;

--- a/src/views/QueryEditorIssues.tsx
+++ b/src/views/QueryEditorIssues.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Input, Select, InlineField } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { IssuesOptions, IssueTimeField } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
 import { components } from 'components/selectors';
+import { IssueTimeField } from '../constants';
+import type { IssuesOptions } from '../types/query';
 
 interface Props extends IssuesOptions {
   onChange: (value: IssuesOptions) => void;

--- a/src/views/QueryEditorLabels.tsx
+++ b/src/views/QueryEditorLabels.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Input, InlineField } from '@grafana/ui';
-
-import { LabelsOptions } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import type { LabelsOptions } from '../types/query';
 
 interface Props extends LabelsOptions {
   onChange: (value: LabelsOptions) => void;

--- a/src/views/QueryEditorMilestones.tsx
+++ b/src/views/QueryEditorMilestones.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
-
 import { Input, InlineField } from '@grafana/ui';
-
-import { MilestonesOptions } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import type { MilestonesOptions } from '../types/query';
 
 interface Props extends MilestonesOptions {
   onChange: (value: MilestonesOptions) => void;

--- a/src/views/QueryEditorPackages.test.tsx
+++ b/src/views/QueryEditorPackages.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import QueryEditorIssues, { DefaultPackageType } from './QueryEditorPackages';
 import { render } from '@testing-library/react';
-import { PackageType } from 'types';
+import { PackageType } from './../constants';
 
 describe('QueryEditorPackages', () => {
   it('should update package type to default one if no package is selected', async () => {

--- a/src/views/QueryEditorPackages.tsx
+++ b/src/views/QueryEditorPackages.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
-
 import { Input, Select, InlineField } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-
-import { PackagesOptions, PackageType } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import { PackageType } from '../constants';
+import type { PackagesOptions } from '../types/query';
 
 interface Props extends PackagesOptions {
   onChange: (value: PackagesOptions) => void;

--- a/src/views/QueryEditorProjects.tsx
+++ b/src/views/QueryEditorProjects.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { Input, InlineLabel, RadioButtonGroup, InlineField } from '@grafana/ui';
-
 import { QueryEditorRow } from '../components/Forms';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
 import { components } from '../components/selectors';
-import { ProjectsOptions, ProjectQueryType } from 'types';
 import { SelectableValue } from '@grafana/data';
 import { Filter, Filters } from 'components/Filters';
+import { ProjectQueryType } from './../constants';
+import type { ProjectsOptions } from 'types/query';
 
 interface Props extends ProjectsOptions {
   onChange: (value: ProjectsOptions) => void;

--- a/src/views/QueryEditorPullRequests.tsx
+++ b/src/views/QueryEditorPullRequests.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-
 import { Input, Select, InlineField } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-
-import { PullRequestsOptions, PullRequestTimeField } from '../types';
-
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import { PullRequestTimeField } from '../constants';
+import type { PullRequestsOptions } from '../types/query';
 
 interface Props extends PullRequestsOptions {
   onChange: (value: PullRequestsOptions) => void;

--- a/src/views/QueryEditorRepository.tsx
+++ b/src/views/QueryEditorRepository.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Input, InlineLabel } from '@grafana/ui';
-
 import { QueryEditorRow } from '../components/Forms';
-import { RepositoryOptions } from '../types';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
 import { components } from '../components/selectors';
+import type { RepositoryOptions } from '../types/query';
 
 interface Props extends RepositoryOptions {
   onChange: (value: RepositoryOptions) => void;

--- a/src/views/QueryEditorWorkflowUsage.tsx
+++ b/src/views/QueryEditorWorkflowUsage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Input, InlineField } from '@grafana/ui';
 import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
-import { WorkflowUsageOptions } from 'types';
+import type { WorkflowUsageOptions } from 'types/query';
 
 interface Props extends WorkflowUsageOptions {
   onChange: (value: WorkflowUsageOptions) => void;

--- a/src/views/QueryEditorWorkflows.tsx
+++ b/src/views/QueryEditorWorkflows.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Select, InlineField } from '@grafana/ui';
-import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
-import { WorkflowsOptions, WorkflowsTimeField } from 'types';
 import { SelectableValue } from '@grafana/data';
+import { RightColumnWidth, LeftColumnWidth } from './QueryEditor';
+import { WorkflowsTimeField } from './../constants';
+import type { WorkflowsOptions } from 'types/query';
 
 interface Props extends WorkflowsOptions {
   onChange: (value: WorkflowsOptions) => void;

--- a/src/views/VariableQueryEditor.tsx
+++ b/src/views/VariableQueryEditor.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo, useState } from 'react';
-
 import { InlineField } from '@grafana/ui';
-
 import QueryEditor from './QueryEditor';
 import { GitHubDataSource } from '../DataSource';
-import { GitHubVariableQuery, DefaultQueryType } from '../types';
 import FieldSelect from '../components/FieldSelect';
 import { isValid } from '../validation';
+import { DefaultQueryType } from '../constants';
+import type { GitHubVariableQuery } from '../types/query';
 
 interface Props {
   query: GitHubVariableQuery;


### PR DESCRIPTION
follow-up of https://github.com/grafana/github-datasource/pull/387#pullrequestreview-2461579074

just moving around query related types and constants.