### PR TITLE
Remove deprecated experimental error source and fix some error sources

### DIFF
--- a/pkg/dfutil/framer.go
+++ b/pkg/dfutil/framer.go
@@ -3,7 +3,6 @@ package dfutil
 import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // Framer is an interface that allows any type to be treated as a data frame
@@ -22,7 +21,10 @@ func FrameResponse(f Framer) backend.DataResponse {
 // This function is particularly useful if you have a function that returns `(Framer, error)`, which is a very common pattern
 func FrameResponseWithError(f Framer, err error) backend.DataResponse {
 	if err != nil {
-		res := errorsource.Response(err)
+		if backend.IsDownstreamHTTPError(err) {
+			err = backend.DownstreamError(err)
+		}
+		res := backend.ErrorResponseWithErrorSource(err)
 		backend.Logger.Debug("Error response", "errorsource", res.ErrorSource, "error", res.Error)
 		return res
 	}

--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -1,16 +1,13 @@
 package githubclient
 
 import (
-	"context"
 	"errors"
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 
 	googlegithub "github.com/google/go-github/v53/github"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 var statusErrorStringFromGraphQLPackage = "non-200 OK status code: "
@@ -19,9 +16,11 @@ var (
 	downstreamErrors = []string{
 		"Could not resolve to",
 		"Your token has not been granted the required scopes to execute this query",
-		"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.",
+		"Resource protected by organization SAML enforcement",
+		"Resource not accessible by personal access token",
 		"API rate limit exceeded",
 		"Resource not accessible by integration", // issue with incorrectly set permissions for token/app
+		"registry is not supported by GraphQL APIs",
 	}
 )
 
@@ -31,13 +30,13 @@ func addErrorSourceToError(err error, resp *googlegithub.Response) error {
 		return nil
 	}
 
-	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, context.Canceled)  {
-		return errorsource.DownstreamError(err, false)
+	if backend.IsDownstreamHTTPError(err) {
+		return backend.DownstreamError(err)
 	}
 
 	for _, downstreamError := range downstreamErrors {
 		if strings.Contains(err.Error(), downstreamError) {
-			return errorsource.DownstreamError(err, false)
+			return backend.DownstreamError(err)
 		}
 	}
 	// Unfortunately graphql library that is used is not returning original error from the client.
@@ -46,13 +45,19 @@ func addErrorSourceToError(err error, resp *googlegithub.Response) error {
 	if strings.Contains(err.Error(), statusErrorStringFromGraphQLPackage) {
 		statusCode, statusErr := extractStatusCode(err)
 		if statusErr == nil {
-			return errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(statusCode), err, false)
+			if backend.ErrorSourceFromHTTPStatus(statusCode) == backend.ErrorSourceDownstream {
+				return backend.DownstreamError(err)
+			}
+			return backend.PluginError(err)
 		}
 	}
 	// If we have response we can use the status code from it
 	if resp != nil {
 		if resp.StatusCode/100 != 2 {
-			return errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(resp.StatusCode), err, false)
+			if backend.ErrorSourceFromHTTPStatus(resp.StatusCode) == backend.ErrorSourceDownstream {
+				return backend.DownstreamError(err)
+			}
+			return backend.PluginError(err)
 		}
 	}
 	// Otherwise we are not adding source which means it is going to be plugin error

--- a/pkg/github/client/errorsourcehandling_test.go
+++ b/pkg/github/client/errorsourcehandling_test.go
@@ -9,7 +9,6 @@ import (
 
 	googlegithub "github.com/google/go-github/v53/github"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,25 +29,25 @@ func TestAddErrorSourceToError(t *testing.T) {
 			name:     "ECONNREFUSED error",
 			err:      syscall.ECONNREFUSED,
 			resp:     nil,
-			expected: errorsource.DownstreamError(syscall.ECONNREFUSED, false),
+			expected: backend.DownstreamError(syscall.ECONNREFUSED),
 		},
 		{
 			name:     "graphql error with status code",
 			err:      errors.New("non-200 OK status code: 404 Not Found"),
 			resp:     nil,
-			expected: errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(404), errors.New("non-200 OK status code: 404 Not Found"), false),
+			expected: backend.DownstreamError(errors.New("non-200 OK status code: 404 Not Found")),
 		},
 		{
 			name:     "identified downstream graphql error",
 			err:      errors.New("Your token has not been granted the required scopes to execute this query"),
 			resp:     nil,
-			expected: errorsource.DownstreamError(errors.New("Your token has not been granted the required scopes to execute this query"),false),
+			expected: backend.DownstreamError(errors.New("Your token has not been granted the required scopes to execute this query")),
 		},
 		{
 			name:     "response with non-2xx status code",
 			err:      errors.New("some other error"),
 			resp:     &googlegithub.Response{Response: &http.Response{StatusCode: 500}},
-			expected: errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(500), errors.New("some other error"), false),
+			expected: backend.DownstreamError(errors.New("some other error")),
 		},
 		{
 			name:     "other error with 2xx status code",
@@ -60,25 +59,25 @@ func TestAddErrorSourceToError(t *testing.T) {
 			name:     "context canceled error",
 			err:      context.Canceled,
 			resp:     nil,
-			expected: errorsource.DownstreamError(context.Canceled, false),
+			expected: backend.DownstreamError(context.Canceled),
 		},
 		{
 			name: "saml error message",
 			err: errors.New("Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization."),
 			resp: nil,
-			expected: errorsource.DownstreamError(errors.New("Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization."), false),
+			expected: backend.DownstreamError(errors.New("Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.")),
 		},
 		{
 			name: "limit exceeded error message",
 			err: errors.New("API rate limit exceeded for ID 1"),
 			resp: nil,
-			expected: errorsource.DownstreamError(errors.New("API rate limit exceeded for ID 1"), false),
+			expected: backend.DownstreamError(errors.New("API rate limit exceeded for ID 1")),
 		},
 		{
 			name: "permission error message",
 			err: errors.New("Resource not accessible by integration"),
 			resp: nil,
-			expected: errorsource.DownstreamError(errors.New("Resource not accessible by integration"), false),
+			expected: backend.DownstreamError(errors.New("Resource not accessible by integration")),
 		},
 	}
 

--- a/pkg/github/query_handler.go
+++ b/pkg/github/query_handler.go
@@ -32,6 +32,7 @@ func UnmarshalQuery(b []byte, v interface{}) *backend.DataResponse {
 	if err := json.Unmarshal(b, v); err != nil {
 		return &backend.DataResponse{
 			Error: errors.Wrap(err, "failed to unmarshal JSON request into query"),
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR removes usage of deprecated experimental error source package and fixes error source for `registry is not supported by GraphQL APIs` error as we are letting user know this is not working anymore. 