### PR TITLE
Fix: Enterprise url needs http path for app auth

### DIFF
--- a/pkg/github/client/client.go
+++ b/pkg/github/client/client.go
@@ -88,7 +88,7 @@ func createAppClient(settings models.Settings) (*Client, error) {
 		}, nil
 	}
 
-	itr.BaseURL = settings.GitHubURL
+	itr.BaseURL = fmt.Sprintf("%s/api/v3", settings.GitHubURL)
 
 	return useGitHubEnterprise(httpClient, settings)
 }


### PR DESCRIPTION
I am sorry, my last fix wasn't complete and resulted in another error. This has been tested with our enterprise server instance successfully. @zoltanbedi 

#430 #426 