### PR TITLE
Fix: Append /api/v3 to GitHub Enterprise URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.2]
+
+- **Fix** - GitHub enterprise url missing /api/v3
+
 ## [2.1.1]
 
 - **Fix** - GitHub enterprise url wrong with app authentication

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-github-datasource",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "The GitHub data source plugin for Grafana lets you to query the GitHub API in Grafana so you can visualize your GitHub repositories and projects.",
   "repository": "github:grafana/github-datasource",

--- a/pkg/github/client/client.go
+++ b/pkg/github/client/client.go
@@ -88,7 +88,7 @@ func createAppClient(settings models.Settings) (*Client, error) {
 		}, nil
 	}
 
-	itr.BaseURL = settings.GitHubURL
+	itr.BaseURL = fmt.Sprintf("%s/api/v3", settings.GitHubURL)
 
 	return useGitHubEnterprise(httpClient, settings)
 }


### PR DESCRIPTION
Original PR by @lehmanju https://github.com/grafana/github-datasource/pull/431