### PR TITLE
Package: Validate package types

### DIFF
--- a/.changeset/stupid-teams-trade.md
+++ b/.changeset/stupid-teams-trade.md
@@ -1,0 +1,5 @@
+---
+'grafana-github-datasource': patch
+---
+
+chore: Add validation for package types

--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -20,7 +20,6 @@ var (
 		"Resource not accessible by personal access token",
 		"API rate limit exceeded",
 		"Resource not accessible by integration", // issue with incorrectly set permissions for token/app
-		"registry is not supported by GraphQL APIs",
 	}
 )
 

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -117,7 +117,10 @@ func (d *Datasource) HandleMilestonesQuery(ctx context.Context, query *models.Mi
 
 // HandlePackagesQuery is the query handler for listing GitHub Packages
 func (d *Datasource) HandlePackagesQuery(ctx context.Context, query *models.PackagesQuery, req backend.DataQuery) (dfutil.Framer, error) {
-	opt := models.PackagesOptionsWithRepo(query.Options, query.Owner, query.Repository)
+	opt, err := models.PackagesOptionsWithRepo(query.Options, query.Owner, query.Repository)
+	if err != nil {
+		return nil, err
+	}
 
 	return GetAllPackages(ctx, d.client, opt)
 }

--- a/pkg/models/packages.go
+++ b/pkg/models/packages.go
@@ -18,7 +18,7 @@ type ListPackagesOptions struct {
 
 // PackagesOptionsWithRepo adds Owner and Repo to a ListPackagesOptions. This is just for convenience
 func PackagesOptionsWithRepo(opt ListPackagesOptions, owner string, repo string) (ListPackagesOptions, error) {
-	validPackageType, err := validatePackageType(opt.PackageType)
+	err := validatePackageType(opt.PackageType)
 	if err != nil {
 		return ListPackagesOptions{}, err
 	}
@@ -27,7 +27,7 @@ func PackagesOptionsWithRepo(opt ListPackagesOptions, owner string, repo string)
 		Owner:       owner,
 		Repository:  repo,
 		Names:       opt.Names,
-		PackageType: validPackageType,
+		PackageType: opt.PackageType,
 	}, nil
 }
 
@@ -47,13 +47,13 @@ var notSupportedPackageTypes = []githubv4.PackageType{
 	githubv4.PackageTypeNuget,
 }
 
-func validatePackageType(packageType githubv4.PackageType) (githubv4.PackageType, error) {
+func validatePackageType(packageType githubv4.PackageType) error {
 	if slices.Contains(validPackageTypes, packageType) {
-		return packageType, nil
+		return nil
 	}
 
 	if slices.Contains(notSupportedPackageTypes, packageType) {
-		return "", backend.DownstreamError(fmt.Errorf("package type %q is not supported. Valid types are: MAVEN, DOCKER, DEBIAN, PYPI", packageType))
+		return backend.DownstreamError(fmt.Errorf("package type %q is not supported. Valid types are: MAVEN, DOCKER, DEBIAN, PYPI", packageType))
 	}
-	return "", backend.DownstreamError(fmt.Errorf("invalid package type %q. Valid types are: MAVEN, DOCKER, DEBIAN, PYPI", packageType))
+	return backend.DownstreamError(fmt.Errorf("invalid package type %q. Valid types are: MAVEN, DOCKER, DEBIAN, PYPI", packageType))
 }

--- a/pkg/models/packages_test.go
+++ b/pkg/models/packages_test.go
@@ -1,0 +1,95 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validatePackageType(t *testing.T) {
+	tests := []struct {
+		name        string
+		packageType githubv4.PackageType
+		wantType    githubv4.PackageType
+		wantErr     bool
+		errMessage  string
+	}{
+		// Valid package types
+		{
+			name:        "valid PYPI package type",
+			packageType: githubv4.PackageTypePypi,
+			wantType:    githubv4.PackageTypePypi,
+			wantErr:     false,
+		},
+		{
+			name:        "valid Docker package type",
+			packageType: githubv4.PackageTypeDocker,
+			wantType:    githubv4.PackageTypeDocker,
+			wantErr:     false,
+		},
+		{
+			name:        "valid Maven package type",
+			packageType: githubv4.PackageTypeMaven,
+			wantType:    githubv4.PackageTypeMaven,
+			wantErr:     false,
+		},
+		{
+			name:        "valid Debian package type",
+			packageType: githubv4.PackageTypeDebian,
+			wantType:    githubv4.PackageTypeDebian,
+			wantErr:     false,
+		},
+		// Not supported package types by GraphQL API anymore
+		{
+			name:        "not supported NPM package type",
+			packageType: githubv4.PackageTypeNpm,
+			wantType:    "",
+			wantErr:     true,
+			errMessage:  `package type "NPM" is not supported`,
+		},
+		{
+			name:        "not supported Rubygems package type",
+			packageType: githubv4.PackageTypeRubygems,
+			wantType:    "",
+			wantErr:     true,
+			errMessage:  `package type "RUBYGEMS" is not supported`,
+		},
+		{
+			name:        "not supported Nuget package type",
+			packageType: githubv4.PackageTypeNuget,
+			wantType:    "",
+			wantErr:     true,
+			errMessage:  `package type "NUGET" is not supported`,
+		},
+		// Invalid package types
+		{
+			name:        "invalid package type",
+			packageType: "INVALID",
+			wantType:    "",
+			wantErr:     true,
+			errMessage:  `invalid package type "INVALID"`,
+		},
+		{
+			name:        "empty package type",
+			packageType: "",
+			wantType:    "",
+			wantErr:     true,
+			errMessage:  `invalid package type ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, err := validatePackageType(tt.packageType)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errMessage)
+				require.Equal(t, tt.wantType, gotType)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantType, gotType)
+			}
+		})
+	}
+} 

--- a/pkg/models/packages_test.go
+++ b/pkg/models/packages_test.go
@@ -11,7 +11,6 @@ func Test_validatePackageType(t *testing.T) {
 	tests := []struct {
 		name        string
 		packageType githubv4.PackageType
-		wantType    githubv4.PackageType
 		wantErr     bool
 		errMessage  string
 	}{
@@ -19,46 +18,39 @@ func Test_validatePackageType(t *testing.T) {
 		{
 			name:        "valid PYPI package type",
 			packageType: githubv4.PackageTypePypi,
-			wantType:    githubv4.PackageTypePypi,
 			wantErr:     false,
 		},
 		{
 			name:        "valid Docker package type",
 			packageType: githubv4.PackageTypeDocker,
-			wantType:    githubv4.PackageTypeDocker,
 			wantErr:     false,
 		},
 		{
 			name:        "valid Maven package type",
 			packageType: githubv4.PackageTypeMaven,
-			wantType:    githubv4.PackageTypeMaven,
 			wantErr:     false,
 		},
 		{
 			name:        "valid Debian package type",
 			packageType: githubv4.PackageTypeDebian,
-			wantType:    githubv4.PackageTypeDebian,
 			wantErr:     false,
 		},
 		// Not supported package types by GraphQL API anymore
 		{
 			name:        "not supported NPM package type",
 			packageType: githubv4.PackageTypeNpm,
-			wantType:    "",
 			wantErr:     true,
 			errMessage:  `package type "NPM" is not supported`,
 		},
 		{
 			name:        "not supported Rubygems package type",
 			packageType: githubv4.PackageTypeRubygems,
-			wantType:    "",
 			wantErr:     true,
 			errMessage:  `package type "RUBYGEMS" is not supported`,
 		},
 		{
 			name:        "not supported Nuget package type",
 			packageType: githubv4.PackageTypeNuget,
-			wantType:    "",
 			wantErr:     true,
 			errMessage:  `package type "NUGET" is not supported`,
 		},
@@ -66,14 +58,12 @@ func Test_validatePackageType(t *testing.T) {
 		{
 			name:        "invalid package type",
 			packageType: "INVALID",
-			wantType:    "",
 			wantErr:     true,
 			errMessage:  `invalid package type "INVALID"`,
 		},
 		{
 			name:        "empty package type",
 			packageType: "",
-			wantType:    "",
 			wantErr:     true,
 			errMessage:  `invalid package type ""`,
 		},
@@ -81,14 +71,12 @@ func Test_validatePackageType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotType, err := validatePackageType(tt.packageType)
+			err := validatePackageType(tt.packageType)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.errMessage)
-				require.Equal(t, tt.wantType, gotType)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.wantType, gotType)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds package type check/validation.

It fixes https://github.com/grafana/data-sources/issues/386 error that is return by github api that happens if the package type is random non-supported string. 

And also it is also improvement for package types that are valid, but not supported by graphql and return errors (more in  https://github.com/grafana/github-datasource/pull/366.) So instead of sending package type we know will return error, we return error early with helpful message.

[Ok DOCKER package](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22g9y%22:%7B%22datasource%22:%22ddyrfpv6iitj4b%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-github-datasource%22,%22uid%22:%22ddyrfpv6iitj4b%22%7D,%22queryType%22:%22Packages%22,%22options%22:%7B%22packageType%22:%22DOCKER%22%7D,%22repository%22:%22grafana%22,%22owner%22:%22grafana%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/e6bce93d-9d61-4a88-8fd9-84f114fa6cfe" />

[Not supported NPM package](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22g9y%22:%7B%22datasource%22:%22ddyrfpv6iitj4b%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-github-datasource%22,%22uid%22:%22ddyrfpv6iitj4b%22%7D,%22queryType%22:%22Packages%22,%22options%22:%7B%22packageType%22:%22NPM%22%7D,%22repository%22:%22grafana%22,%22owner%22:%22grafana%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/cef5fe39-d7e8-4ba0-aca6-1b80caa87e4b" />

[Invalid "abc" package](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22g9y%22%3A%7B%22datasource%22%3A%22ddyrfpv6iitj4b%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22grafana-github-datasource%22%2C%22uid%22%3A%22ddyrfpv6iitj4b%22%7D%2C%22queryType%22%3A%22Packages%22%2C%22options%22%3A%7B%22packageType%22%3A%22abc%22%7D%2C%22repository%22%3A%22grafana%22%2C%22owner%22%3A%22grafana%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1)
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/07e1eeb5-46dd-47c8-a971-75c08865ad15" />

