### PR TITLE
Workflows: Fix error source when unexpected time field is used

### DIFF
--- a/pkg/github/workflows.go
+++ b/pkg/github/workflows.go
@@ -88,7 +88,7 @@ func keepWorkflowsInTimeRange(workflows []*googlegithub.Workflow, timeField mode
 			}
 
 		default:
-			return nil, fmt.Errorf("unexpected time field: %d", timeField)
+			return nil, backend.DownstreamError(fmt.Errorf("unexpected time field: %d", timeField))
 		}
 
 		out = append(out, workflow)


### PR DESCRIPTION
We support 2 time fields and use `0` and `1` to distinguish them. If user uses any other time fields `2`, `3`, ... this causes an error as it is not supported. The error should be downstream. 
<img width="636" alt="image" src="https://github.com/user-attachments/assets/96bd3b67-1260-421d-bdb4-3276d7d620cb" />

After fix:
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/7ca6f2f1-beb2-43dd-9674-e8ba45eb50ec" />

