### PR TITLE
Projects: Fix panic caused by newly added enum

### DIFF
--- a/.changeset/moody-news-learn.md
+++ b/.changeset/moody-news-learn.md
@@ -1,0 +1,5 @@
+---
+'grafana-github-datasource': patch
+---
+
+Fix panic in project query

--- a/pkg/github/projects/project_items.go
+++ b/pkg/github/projects/project_items.go
@@ -241,6 +241,8 @@ var fieldTypes = map[string]any{
 var exclude = map[string]bool{
 	"LINKED_PULL_REQUESTS": true,
 	"TRACKED_BY":           true,
+	"PARENT_ISSUE":         true,
+	"SUB_ISSUES_PROGRESS":  true,
 }
 
 // convert fieldValue to time

--- a/pkg/github/projects/project_items.go
+++ b/pkg/github/projects/project_items.go
@@ -32,6 +32,12 @@ func (p ProjectItemsWithFields) Frames() data.Frames {
 			continue
 		}
 		fieldType := fieldTypes[f.Common.DataType]
+		// there might be added new fields where we don't have a type yet, so we will skip them
+		// we will log a debug message so we can add a type for them
+		if fieldType == nil {
+			backend.Logger.Debug("no type for field in project items", "field", f.Common.Name, "dataType", f.Common.DataType)
+			continue
+		}
 		field := data.NewField(f.Common.Name, nil, fieldType)
 		frame.Fields = append(frame.Fields, field)
 		fields = append(fields, f)


### PR DESCRIPTION
Recently following enums where added to project graphql query  https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2025-02-01-1:

- Enum value 'PARENT_ISSUEwas added to enumProjectV2FieldType'
- Enum value 'SUB_ISSUES_PROGRESSwas added to enumProjectV2FieldType'


As we didn't have processing for these, and they weren't in the `fieldTypes` or `exclude` list `fieldType := fieldTypes[f.Common.DataType]` returned `nil` which caused panic in `field := data.NewField(f.Common.Name, nil, fieldType)` as fieldType can't be nil. 

To fix this, we have added these new enums to `exclude` so we can add processing for them later. Moreover, we have added a logic to check if `fieldType == nil` and in that case `continue`, but create a log so we might be more aware of this new enum.  


More in https://raintank-corp.slack.com/archives/C05K271Q8F5/p1742559654567789?thread_ts=1742486345.609529&cid=C05K271Q8F5