### PR TITLE
Fix: workflow runs time filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.4]
+
+- **Fix** - Workflow runs - date filter now filters by time
+
 ## [2.1.3]
 
 - **Fix** - Add mutex protection to prevent data races in datasource cache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-github-datasource",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "description": "The GitHub data source plugin for Grafana lets you to query the GitHub API in Grafana so you can visualize your GitHub repositories and projects.",
   "repository": "github:grafana/github-datasource",

--- a/pkg/github/client/client.go
+++ b/pkg/github/client/client.go
@@ -308,7 +308,7 @@ func (client *Client) getWorkflowRuns(ctx context.Context, owner, repo, workflow
 
 	workflowRuns := []*googlegithub.WorkflowRun{}
 
-	format := "2006-01-02"
+	format := time.RFC3339
 	created := fmt.Sprintf("%s..%s", timeRange.From.Format(format), timeRange.To.Format(format))
 
 	var (


### PR DESCRIPTION
The time filter for workflow runs was limited to day.  The date format didn't include time.

Can now see fine grained results by time:

![image](https://github.com/user-attachments/assets/c8716600-4d5d-43e6-9f61-91042a9413a3)
