### PR TITLE
Feat: Add security code scanning section

### DIFF
--- a/pkg/github/client/client.go
+++ b/pkg/github/client/client.go
@@ -151,6 +151,15 @@ func (client *Client) ListWorkflows(ctx context.Context, owner, repo string, opt
 	return wf, resp, err
 }
 
+// ListAlertsForRepo sends a request to the GitHub rest API to list the code scanning alerts in a specific repository.
+func (client *Client) ListAlertsForRepo(ctx context.Context, owner, repo string, opts *googlegithub.AlertListOptions) ([]*googlegithub.Alert, *googlegithub.Response, error) {
+	alerts, resp, err := client.restClient.CodeScanning.ListAlertsForRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, nil, addErrorSourceToError(err, resp)
+	}
+	return alerts, resp, err
+}
+
 // GetWorkflowUsage returns the workflow usage for a specific workflow.
 func (client *Client) GetWorkflowUsage(ctx context.Context, owner, repo, workflow string, timeRange backend.TimeRange) (models.WorkflowUsage, error) {
 	actors := make(map[string]struct{}, 0)

--- a/pkg/github/codescanning.go
+++ b/pkg/github/codescanning.go
@@ -1,0 +1,164 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	googlegithub "github.com/google/go-github/v53/github"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/github-datasource/pkg/models"
+)
+
+type CodeScanningWrapper []*googlegithub.Alert
+
+func (alerts CodeScanningWrapper) Frames() data.Frames {
+	frames := data.NewFrame("code_scanning_alerts",
+		data.NewField("number", nil, []*int64{}),
+		data.NewField("created_at", nil, []time.Time{}),
+		data.NewField("updated_at", nil, []time.Time{}),
+		data.NewField("dismissed_at", nil, []*time.Time{}),
+		data.NewField("url", nil, []string{}),
+		data.NewField("state", nil, []string{}),
+		data.NewField("dismissed_by", nil, []string{}),
+		data.NewField("dismissed_reason", nil, []string{}),
+		data.NewField("dismissed_comment", nil, []string{}),
+		data.NewField("rule_id", nil, []string{}),
+		data.NewField("rule_severity", nil, []string{}),
+		data.NewField("rule_security_severity_level", nil, []string{}),
+		data.NewField("rule_description", nil, []string{}),
+		data.NewField("rule_full_description", nil, []string{}),
+		data.NewField("rule_tags", nil, []string{}),
+		data.NewField("rule_help", nil, []string{}),
+		data.NewField("tool_name", nil, []string{}),
+		data.NewField("tool_version", nil, []string{}),
+		data.NewField("tool_guid", nil, []string{}),
+	)
+
+	for _, alert := range alerts {
+		frames.AppendRow(
+			func() *int64 {
+				num := int64(alert.GetNumber())
+				return &num
+			}(),
+			func() time.Time {
+				if !alert.GetCreatedAt().Time.IsZero() {
+					return alert.GetCreatedAt().Time
+				}
+				return time.Time{}
+			}(),
+			func() time.Time {
+				if !alert.GetUpdatedAt().Time.IsZero() {
+					return alert.GetUpdatedAt().Time
+				}
+				return time.Time{}
+			}(),
+			func() *time.Time {
+				if !alert.GetDismissedAt().Time.IsZero() {
+					t := alert.GetDismissedAt().Time
+					return &t
+				}
+				return nil
+			}(),
+			func() string {
+				str := alert.GetHTMLURL()
+				return str
+			}(),
+			func() string {
+				str := alert.GetState()
+				return str
+			}(),
+			func() string {
+				if alert.GetDismissedBy() != nil {
+					str := alert.GetDismissedBy().GetLogin()
+					return str
+				}
+				return ""
+			}(),
+			func() string {
+				str := alert.GetDismissedReason()
+				return str
+			}(),
+			func() string {
+				str := alert.GetDismissedComment()
+				return str
+			}(),
+			func() string {
+				if alert.GetRule() != nil {
+					return *alert.GetRule().ID
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil {
+					return *alert.GetRule().Severity
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil {
+					return *alert.GetRule().SecuritySeverityLevel
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil && alert.GetRule().Description != nil {
+					return *alert.GetRule().Description
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil && alert.GetRule().FullDescription != nil {
+					return *alert.GetRule().FullDescription
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil {
+					str := strings.Join(alert.GetRule().Tags, ", ")
+					return str
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetRule() != nil {
+					return *alert.GetRule().Help
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetTool() != nil && alert.GetTool().Name != nil {
+					return *alert.GetTool().Name
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetTool() != nil && alert.GetTool().Version != nil {
+					return *alert.GetTool().Version
+				}
+				return ""
+			}(),
+			func() string {
+				if alert.GetTool() != nil && alert.GetTool().GUID != nil {
+					return *alert.GetTool().GUID
+				}
+				return ""
+			}(),
+		)
+	}
+
+	return data.Frames{frames}
+}
+
+// GetCodeScanningAlerts to get a list of alerts for a repository
+// GET /repos/{owner}/{repo}/code-scanning/alerts
+// https://docs.github.com/en/rest/reference/code-scanning#get-a-list-of-code-scanning-alerts-for-a-repository
+func GetCodeScanningAlerts(context context.Context, owner, repo string, c models.Client) (CodeScanningWrapper, error) {
+	alerts, _, err := c.ListAlertsForRepo(context, owner, repo, &googlegithub.AlertListOptions{ListOptions: googlegithub.ListOptions{Page: 1, PerPage: 100}})
+	if err != nil {
+		return nil, err
+	}
+
+	return CodeScanningWrapper(alerts), nil
+}

--- a/pkg/github/codescanning.go
+++ b/pkg/github/codescanning.go
@@ -154,8 +154,16 @@ func (alerts CodeScanningWrapper) Frames() data.Frames {
 // GetCodeScanningAlerts to get a list of alerts for a repository
 // GET /repos/{owner}/{repo}/code-scanning/alerts
 // https://docs.github.com/en/rest/reference/code-scanning#get-a-list-of-code-scanning-alerts-for-a-repository
-func GetCodeScanningAlerts(context context.Context, owner, repo string, c models.Client) (CodeScanningWrapper, error) {
-	alerts, _, err := c.ListAlertsForRepo(context, owner, repo, &googlegithub.AlertListOptions{ListOptions: googlegithub.ListOptions{Page: 1, PerPage: 100}})
+func GetCodeScanningAlerts(context context.Context, c models.Client, opt models.CodeScanningOptions, from time.Time, to time.Time) (CodeScanningWrapper, error) {
+	alerts, _, err := c.ListAlertsForRepo(
+		context,
+		opt.Owner,
+		opt.Repository,
+		&googlegithub.AlertListOptions{
+			State: opt.State,
+			Ref:   opt.Ref,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/github/codescanning_handler.go
+++ b/pkg/github/codescanning_handler.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/github-datasource/pkg/dfutil"
+	"github.com/grafana/github-datasource/pkg/models"
+)
+
+func (s *QueryHandler) handleCodeScanningRequests(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+	query := &models.CodeScanningQuery{}
+	if err := UnmarshalQuery(q.JSON, query); err != nil {
+		return *err
+	}
+	return dfutil.FrameResponseWithError(s.Datasource.HandleCodeScanningQuery(ctx, query, q))
+}
+
+// HandleCodeScanning handles the plugin query for github code scanning
+func (s *QueryHandler) HandleCodeScanning(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return &backend.QueryDataResponse{
+		Responses: processQueries(ctx, req, s.handleCodeScanningRequests),
+	}, nil
+}

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -46,6 +46,12 @@ func (d *Datasource) HandleCommitsQuery(ctx context.Context, query *models.Commi
 	return GetCommitsInRange(ctx, d.client, opt, req.TimeRange.From, req.TimeRange.To)
 }
 
+// HandleCodeScanningQuery is the query handler for listing code scanning alerts of a GitHub repository
+func (d *Datasource) HandleCodeScanningQuery(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.CodeScanningOptionsWithRepo(query.Options, query.Owner, query.Repository)
+	return GetCodeScanningAlerts(ctx, d.client, opt, req.TimeRange.From, req.TimeRange.To)
+}
+
 // HandleTagsQuery is the query handler for listing GitHub Tags
 func (d *Datasource) HandleTagsQuery(ctx context.Context, query *models.TagsQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	opt := models.ListTagsOptions{
@@ -136,12 +142,6 @@ func (d *Datasource) HandleVulnerabilitiesQuery(ctx context.Context, query *mode
 	return GetAllVulnerabilities(ctx, d.client, opt)
 }
 
-// ListAlertsForRepo is the query handler for listing GitHub Security Alerts
-func (d *Datasource) ListAlertsForRepo(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
-	opt := models.ListCodeScanningOptionsWithRepo(query.Options, query.Owner, query.Repository)
-	return d.HandleCodeScanningQuery(ctx, &models.CodeScanningQuery{Query: query.Query, Options: opt}, req)
-}
-
 // HandleProjectsQuery is the query handler for listing GitHub Projects
 func (d *Datasource) HandleProjectsQuery(ctx context.Context, query *models.ProjectsQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	opt := models.ProjectOptions{
@@ -200,11 +200,6 @@ func (d *Datasource) HandleWorkflowRunsQuery(ctx context.Context, query *models.
 	}
 
 	return GetWorkflowRuns(ctx, d.client, opt, req.TimeRange)
-}
-
-// HandleCodeScanningQuery is the query handler for listing code scanning alerts of a GitHub repository
-func (d *Datasource) HandleCodeScanningQuery(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
-	return GetCodeScanningAlerts(ctx, query.Owner, query.Repository, d.client)
 }
 
 // CheckHealth is the health check for GitHub

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/github-datasource/pkg/dfutil"
 	githubclient "github.com/grafana/github-datasource/pkg/github/client"
 	"github.com/grafana/github-datasource/pkg/github/projects"
 	"github.com/grafana/github-datasource/pkg/models"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 // Make sure Datasource implements required interfaces.
@@ -135,6 +136,16 @@ func (d *Datasource) HandleVulnerabilitiesQuery(ctx context.Context, query *mode
 	return GetAllVulnerabilities(ctx, d.client, opt)
 }
 
+// ListAlertsForRepo is the query handler for listing GitHub Security Alerts
+func (d *Datasource) ListAlertsForRepo(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.ListCodeScanningOptions{
+		Repository: query.Repository,
+		Owner:      query.Owner,
+	}
+
+	return d.HandleCodeScanningQuery(ctx, &models.CodeScanningQuery{Query: query.Query, Options: opt}, req)
+}
+
 // HandleProjectsQuery is the query handler for listing GitHub Projects
 func (d *Datasource) HandleProjectsQuery(ctx context.Context, query *models.ProjectsQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	opt := models.ProjectOptions{
@@ -193,6 +204,11 @@ func (d *Datasource) HandleWorkflowRunsQuery(ctx context.Context, query *models.
 	}
 
 	return GetWorkflowRuns(ctx, d.client, opt, req.TimeRange)
+}
+
+// HandleCodeScanningQuery is the query handler for listing code scanning alerts of a GitHub repository
+func (d *Datasource) HandleCodeScanningQuery(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	return GetCodeScanningAlerts(ctx, query.Owner, query.Repository, d.client)
 }
 
 // CheckHealth is the health check for GitHub

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -138,11 +138,7 @@ func (d *Datasource) HandleVulnerabilitiesQuery(ctx context.Context, query *mode
 
 // ListAlertsForRepo is the query handler for listing GitHub Security Alerts
 func (d *Datasource) ListAlertsForRepo(ctx context.Context, query *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
-	opt := models.ListCodeScanningOptions{
-		Repository: query.Repository,
-		Owner:      query.Owner,
-	}
-
+	opt := models.ListCodeScanningOptionsWithRepo(query.Options, query.Owner, query.Repository)
 	return d.HandleCodeScanningQuery(ctx, &models.CodeScanningQuery{Query: query.Query, Options: opt}, req)
 }
 

--- a/pkg/github/query_handler.go
+++ b/pkg/github/query_handler.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/grafana/github-datasource/pkg/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/pkg/errors"
+
+	"github.com/grafana/github-datasource/pkg/models"
 )
 
 // QueryHandler is the main handler for datasource queries.
@@ -31,7 +32,7 @@ func processQueries(ctx context.Context, req *backend.QueryDataRequest, handler 
 func UnmarshalQuery(b []byte, v interface{}) *backend.DataResponse {
 	if err := json.Unmarshal(b, v); err != nil {
 		return &backend.DataResponse{
-			Error: errors.Wrap(err, "failed to unmarshal JSON request into query"),
+			Error:       errors.Wrap(err, "failed to unmarshal JSON request into query"),
 			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
@@ -59,6 +60,7 @@ func GetQueryHandlers(s *QueryHandler) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypeWorkflows, s.HandleWorkflows)
 	mux.HandleFunc(models.QueryTypeWorkflowUsage, s.HandleWorkflowUsage)
 	mux.HandleFunc(models.QueryTypeWorkflowRuns, s.HandleWorkflowRuns)
+	mux.HandleFunc(models.QueryTypeCodeScanning, s.HandleCodeScanning)
 
 	return mux
 }

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -14,4 +14,6 @@ type Client interface {
 	ListWorkflows(ctx context.Context, owner, repo string, opts *googlegithub.ListOptions) (*googlegithub.Workflows, *googlegithub.Response, error)
 	GetWorkflowUsage(ctx context.Context, owner, repo, workflow string, timeRange backend.TimeRange) (WorkflowUsage, error)
 	GetWorkflowRuns(ctx context.Context, owner, repo, workflow string, branch string, timeRange backend.TimeRange) ([]*googlegithub.WorkflowRun, error)
+	// ListAlertsForRepo is an interface for getting code security alerts
+	ListAlertsForRepo(ctx context.Context, owner, repo string, opts *googlegithub.AlertListOptions) ([]*googlegithub.Alert, *googlegithub.Response, error)
 }

--- a/pkg/models/codescanning.go
+++ b/pkg/models/codescanning.go
@@ -1,0 +1,12 @@
+package models
+
+type ListCodeScanningOptions struct {
+	// Owner is the owner of the repository (ex: grafana)
+	Owner string `json:"owner"`
+
+	// Repository is the name of the repository being queried (ex: grafana)
+	Repository string `json:"repository"`
+
+	// The field used to check if an entry is in the requested range.
+	TimeField uint32 `json:"timeField"`
+}

--- a/pkg/models/codescanning.go
+++ b/pkg/models/codescanning.go
@@ -1,14 +1,11 @@
 package models
 
-type ListCodeScanningOptions struct {
+type CodeScanningOptions struct {
 	// Owner is the owner of the repository (ex: grafana)
 	Owner string `json:"owner"`
 
 	// Repository is the name of the repository being queried (ex: grafana)
 	Repository string `json:"repository"`
-
-	// The field used to check if an entry is in the requested range.
-	TimeField uint32 `json:"timeField"`
 
 	// State is the state of the code scanning alerts. Can be one of: open, closed, dismissed, fixed.
 	State string `json:"state"`
@@ -19,9 +16,9 @@ type ListCodeScanningOptions struct {
 	Ref string `json:"gitRef"`
 }
 
-// ListCodeScanningOptionsWithRepo adds Owner and Repo to a ListCodeScanningOptions. This is just for convenience
-func ListCodeScanningOptionsWithRepo(opt ListCodeScanningOptions, owner string, repo string) ListCodeScanningOptions {
-	return ListCodeScanningOptions{
+// CodeScanningOptionsWithRepo adds Owner and Repo to a CodeScanningOptions. This is just for convenience
+func CodeScanningOptionsWithRepo(opt CodeScanningOptions, owner string, repo string) CodeScanningOptions {
+	return CodeScanningOptions{
 		Owner:      owner,
 		Repository: repo,
 		Ref:        opt.Ref,

--- a/pkg/models/codescanning.go
+++ b/pkg/models/codescanning.go
@@ -9,4 +9,22 @@ type ListCodeScanningOptions struct {
 
 	// The field used to check if an entry is in the requested range.
 	TimeField uint32 `json:"timeField"`
+
+	// State is the state of the code scanning alerts. Can be one of: open, closed, dismissed, fixed.
+	State string `json:"state"`
+
+	// Ref is the Git reference for the results we want to list.
+	// The ref for a branch can be formatted either as refs/heads/<branch name> or simply <branch name>.
+	// To reference a pull request use refs/pull/<number>/merge.
+	Ref string `json:"gitRef"`
+}
+
+// ListCodeScanningOptionsWithRepo adds Owner and Repo to a ListCodeScanningOptions. This is just for convenience
+func ListCodeScanningOptionsWithRepo(opt ListCodeScanningOptions, owner string, repo string) ListCodeScanningOptions {
+	return ListCodeScanningOptions{
+		Owner:      owner,
+		Repository: repo,
+		Ref:        opt.Ref,
+		State:      opt.State,
+	}
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -39,6 +39,8 @@ const (
 	QueryTypeWorkflowUsage = "Workflow_Usage"
 	// QueryTypeWorkflowRuns is used when querying workflow runs for a repository
 	QueryTypeWorkflowRuns = "Workflow_Runs"
+	// QueryTypeCodeScanning is used when querying code scanning alerts for a repository
+	QueryTypeCodeScanning = "Code_Scanning"
 )
 
 // Query refers to the structure of a query built using the QueryEditor.
@@ -136,4 +138,10 @@ type WorkflowUsageQuery struct {
 type WorkflowRunsQuery struct {
 	Query
 	Options WorkflowRunsOptions `json:"options"`
+}
+
+// CodeScanningQuery is used when querying code scanning alerts for a repository
+type CodeScanningQuery struct {
+	Query
+	Options ListCodeScanningOptions `json:"options"`
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -143,5 +143,5 @@ type WorkflowRunsQuery struct {
 // CodeScanningQuery is used when querying code scanning alerts for a repository
 type CodeScanningQuery struct {
 	Query
-	Options ListCodeScanningOptions `json:"options"`
+	Options CodeScanningOptions `json:"options"`
 }

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -14,6 +14,7 @@ type Datasource interface {
 	HandleRepositoriesQuery(context.Context, *models.RepositoriesQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleIssuesQuery(context.Context, *models.IssuesQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleCommitsQuery(context.Context, *models.CommitsQuery, backend.DataQuery) (dfutil.Framer, error)
+	HandleCodeScanningQuery(context.Context, *models.CodeScanningQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleTagsQuery(context.Context, *models.TagsQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleReleasesQuery(context.Context, *models.ReleasesQuery, backend.DataQuery) (dfutil.Framer, error)
 	HandleContributorsQuery(context.Context, *models.ContributorsQuery, backend.DataQuery) (dfutil.Framer, error)

--- a/pkg/plugin/datasource_caching.go
+++ b/pkg/plugin/datasource_caching.go
@@ -121,6 +121,16 @@ func (c *CachedDatasource) HandleCommitsQuery(ctx context.Context, q *models.Com
 	return c.saveCache(req, f, err)
 }
 
+// HandleCodeScanningQuery is the cache wrapper for the issue query handler
+func (c *CachedDatasource) HandleCodeScanningQuery(ctx context.Context, q *models.CodeScanningQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	if value, err := c.getCache(req); err == nil {
+		return value, err
+	}
+
+	f, err := c.datasource.HandleCodeScanningQuery(ctx, q, req)
+	return c.saveCache(req, f, err)
+}
+
 // HandleTagsQuery is the cache wrapper for the issue query handler
 func (c *CachedDatasource) HandleTagsQuery(ctx context.Context, q *models.TagsQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	if value, err := c.getCache(req); err == nil {

--- a/src/components/selectors.ts
+++ b/src/components/selectors.ts
@@ -20,6 +20,9 @@ export const components = {
     Ref: {
       input: 'Query editor ref',
     },
+    CodeScanState: {
+      input: 'Query editor code scan state',
+    },
     Number: {
       input: 'Query editor number',
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export enum QueryType {
+  Code_Scanning = 'Code_Scanning',
   Commits = 'Commits',
   Issues = 'Issues',
   Contributors = 'Contributors',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -41,6 +41,11 @@ export interface PullRequestsOptions extends Indexable {
   query?: string;
 }
 
+export interface CodeScanningOptions extends Indexable {
+  gitRef?: string;
+  state?: string
+}
+
 export interface CommitsOptions extends Indexable {
   gitRef?: string;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -16,7 +16,8 @@ export const isValid = (query: GitHubQuery): boolean => {
     query.queryType === QueryType.Labels ||
     query.queryType === QueryType.Milestones ||
     query.queryType === QueryType.Vulnerabilities ||
-    query.queryType === QueryType.Stargazers
+    query.queryType === QueryType.Stargazers ||
+    query.queryType === QueryType.Code_Scanning
   ) {
     if (isEmpty(query.owner) || isEmpty(query.repository)) {
       return false;

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -53,7 +53,7 @@ const queryEditors: {
     component: (props: Props, _: (val: any) => void) => <QueryEditorTags {...(props.query.options || {})} />,
   },
   [QueryType.Code_Scanning]: {
-    component: (props: Props, _: (val: any) => void) => <QueryEditorCodeScanning {...(props.query.options || {})} />,
+    component: (props: Props, onChange: (val: any) => void) => <QueryEditorCodeScanning {...(props.query.options || {})}  onChange={onChange} />,
   },
   [QueryType.Releases]: {
     component: (props: Props, _: (val: any) => void) => <QueryEditorReleases {...(props.query.options || {})} />,

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -4,7 +4,7 @@ import { Select, InlineField } from '@grafana/ui';
 
 import { GitHubDataSource } from '../DataSource';
 import { isValid } from '../validation';
-import { components } from './../components/selectors';
+import { components } from '../components/selectors';
 
 import QueryEditorRepository from './QueryEditorRepository';
 import QueryEditorReleases from './QueryEditorReleases';
@@ -21,6 +21,7 @@ import QueryEditorProjects from './QueryEditorProjects';
 import QueryEditorWorkflows from './QueryEditorWorkflows';
 import QueryEditorWorkflowUsage from './QueryEditorWorkflowUsage';
 import QueryEditorWorkflowRuns from './QueryEditorWorkflowRuns';
+import QueryEditorCodeScanning from './QueryEditorCodeScanning';
 import { QueryType, DefaultQueryType } from '../constants';
 import type { GitHubQuery } from '../types/query';
 import type { GitHubDataSourceOptions } from '../types/config';
@@ -50,6 +51,9 @@ const queryEditors: {
   },
   [QueryType.Tags]: {
     component: (props: Props, _: (val: any) => void) => <QueryEditorTags {...(props.query.options || {})} />,
+  },
+  [QueryType.Code_Scanning]: {
+    component: (props: Props, _: (val: any) => void) => <QueryEditorCodeScanning {...(props.query.options || {})} />,
   },
   [QueryType.Releases]: {
     component: (props: Props, _: (val: any) => void) => <QueryEditorReleases {...(props.query.options || {})} />,

--- a/src/views/QueryEditorCodeScanning.tsx
+++ b/src/views/QueryEditorCodeScanning.tsx
@@ -1,4 +1,41 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { LeftColumnWidth, RightColumnWidth } from './QueryEditor';
+import { InlineField, Input } from '@grafana/ui';
+import { components } from '../components/selectors';
+import { CodeScanningOptions } from '../types/query';
 
-const QueryEditorCodeScanning = () => <>code scanning editor</>;
+interface Props extends CodeScanningOptions {
+  onChange: (value: CodeScanningOptions) => void;
+}
+
+const QueryEditorCodeScanning = (props: Props) => {
+  const [state, setState] = useState<string>(props.state || 'open');
+  const [ref, setRef] = useState<string>(props.gitRef || '');
+  return (
+    <>
+      <InlineField
+        labelWidth={LeftColumnWidth * 2}
+        label="State"
+        tooltip="Can be one of: open, closed, dismissed, fixed. Default: open"
+      >
+        <Input
+          aria-label={components.QueryEditor.CodeScanState.input}
+          width={RightColumnWidth}
+          value={state}
+          onChange={(el) => setState(el.currentTarget.value)}
+          onBlur={(el) => props.onChange({ ...props, state: el.currentTarget.value })}
+        />
+      </InlineField>
+      <InlineField labelWidth={LeftColumnWidth * 2} label="Ref (Branch / Tag)">
+        <Input
+          aria-label={components.QueryEditor.Ref.input}
+          width={RightColumnWidth}
+          value={ref}
+          onChange={(el) => setRef(el.currentTarget.value)}
+          onBlur={(el) => props.onChange({ ...props, gitRef: el.currentTarget.value })}
+        />
+      </InlineField>
+    </>
+  );
+};
 export default QueryEditorCodeScanning;

--- a/src/views/QueryEditorCodeScanning.tsx
+++ b/src/views/QueryEditorCodeScanning.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+const QueryEditorCodeScanning = () => <>code scanning editor</>;
+export default QueryEditorCodeScanning;


### PR DESCRIPTION
This introduces Security / Code Scanning Results page in a given github repo;

![image](https://github.com/user-attachments/assets/f15ac421-3de0-485c-af48-2ec139e7b06e)

Originally introduced here: https://github.com/grafana/github-datasource/pull/377

