### PR TITLE
Return assignees with issues queries

### DIFF
--- a/docs/sources/query/_index.md
+++ b/docs/sources/query/_index.md
@@ -124,6 +124,7 @@ Show all issues with 'sql expressions' in the title:
 | closed_at      | When the issue was closed: YYYY-MM-DD HH:MM:SS |
 | updated_at     | When the issue was last updated: YYYY-MM-DD HH:MM:SS |
 | labels         | Array of labels, for example: `["type/bug", "needs more info"]` |
+| assignees      | Array of assignees, for example: `["user1", "user2"]` |
 
 ### Contributors
 

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -26,6 +26,11 @@ type Issue struct {
 			Name string
 		}
 	} `graphql:"labels(first: 100)"`
+	Assignees struct {
+		Nodes []struct {
+			models.User
+		}
+	} `graphql:"assignees(first: 10)"`
 	Author struct {
 		models.User `graphql:"... on User"`
 	}
@@ -49,6 +54,7 @@ func (c Issues) Frames() data.Frames {
 		data.NewField("closed_at", nil, []*time.Time{}),
 		data.NewField("updated_at", nil, []time.Time{}),
 		data.NewField("labels", nil, []json.RawMessage{}),
+		data.NewField("assignees", nil, []json.RawMessage{}),
 	)
 
 	for _, v := range c {
@@ -63,8 +69,16 @@ func (c Issues) Frames() data.Frames {
 			labels[i] = label.Name
 		}
 
+		assignees := make([]string, len(v.Assignees.Nodes))
+		for i, assignee := range v.Assignees.Nodes {
+			assignees[i] = assignee.User.Login
+		}
+
 		labelsBytes, _ := json.Marshal(labels)
 		rawLabelArray := json.RawMessage(labelsBytes)
+		
+		assigneesBytes, _ := json.Marshal(assignees)
+		rawAssigneesArray := json.RawMessage(assigneesBytes)
 
 		frame.AppendRow(
 			v.Title,
@@ -77,6 +91,7 @@ func (c Issues) Frames() data.Frames {
 			closedAt,
 			v.UpdatedAt.Time,
 			rawLabelArray,
+			rawAssigneesArray,
 		)
 	}
 

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -53,17 +53,13 @@ func TestIssuesDataframe(t *testing.T) {
 				Time: createdAt,
 			},
 			Closed: false,
-			Labels: struct {
-				Nodes []struct{ Name string }
-			}{
+			Labels: struct { Nodes []struct{ Name string } }{
 				Nodes: []struct{ Name string }{
-					{Name: "bug"},
-					{Name: "help wanted"},
+					{ Name: "bug" },
+					{ Name: "help wanted" },
 				},
 			},
-			Author: struct {
-				models.User "graphql:\"... on User\""
-			}{
+			Author: struct { models.User "graphql:\"... on User\"" }{
 				User: models.User{
 					ID:      "1",
 					Login:   "firstUser",
@@ -71,6 +67,12 @@ func TestIssuesDataframe(t *testing.T) {
 					Company: "ACME Corp",
 					Email:   "first@example.com",
 					URL:     "",
+				},
+			},
+			Assignees: struct { Nodes []struct { models.User } }{
+				Nodes: []struct { models.User }{
+					{ User: models.User{ Login: "firstUser" } },
+					{ User: models.User{ Login: "secondUser" } },
 				},
 			},
 			Repository: Repository{
@@ -102,16 +104,12 @@ func TestIssuesDataframe(t *testing.T) {
 				Time: createdAt.Add(time.Hour * 6),
 			},
 			Closed: true,
-			Labels: struct {
-				Nodes []struct{ Name string }
-			}{
+			Labels: struct { Nodes []struct{ Name string } }{
 				Nodes: []struct{ Name string }{
-					{Name: "enhancement"},
+					{ Name: "enhancement" },
 				},
 			},
-			Author: struct {
-				models.User "graphql:\"... on User\""
-			}{
+			Author: struct { models.User "graphql:\"... on User\"" }{
 				User: models.User{
 					ID:      "2",
 					Login:   "secondUser",
@@ -119,6 +117,11 @@ func TestIssuesDataframe(t *testing.T) {
 					Company: "ACME Corp",
 					Email:   "second@example.com",
 					URL:     "",
+				},
+			},
+			Assignees: struct { Nodes []struct { models.User } }{
+				Nodes: []struct { models.User }{
+					{ User: models.User{ Login: "firstUser" } },
 				},
 			},
 			Repository: Repository{
@@ -150,14 +153,10 @@ func TestIssuesDataframe(t *testing.T) {
 				Time: createdAt,
 			},
 			Closed: false,
-			Labels: struct {
-				Nodes []struct{ Name string }
-			}{
+			Labels: struct { Nodes []struct{ Name string } }{
 				Nodes: []struct{ Name string }{},
 			},
-			Author: struct {
-				models.User "graphql:\"... on User\""
-			}{
+			Author: struct { models.User "graphql:\"... on User\"" }{
 				User: models.User{
 					ID:      "3",
 					Login:   "firstUser",
@@ -166,6 +165,9 @@ func TestIssuesDataframe(t *testing.T) {
 					Email:   "first@example.com",
 					URL:     "",
 				},
+			},
+			Assignees: struct { Nodes []struct { models.User }}{
+				Nodes: []struct { models.User }{},
 			},
 			Repository: Repository{
 				Name: "grafana",

--- a/pkg/github/testdata/issues.golden.jsonc
+++ b/pkg/github/testdata/issues.golden.jsonc
@@ -2,16 +2,16 @@
 //  
 //  Frame[0] 
 //  Name: issues
-//  Dimensions: 10 Fields by 3 Rows
-//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+
-//  | Name: title    | Name: author   | Name: author_company | Name: repo      | Name: number  | Name: closed | Name: created_at                | Name: closed_at                 | Name: updated_at                | Name: labels            |
-//  | Labels:        | Labels:        | Labels:              | Labels:         | Labels:       | Labels:      | Labels:                         | Labels:                         | Labels:                         | Labels:                 |
-//  | Type: []string | Type: []string | Type: []string       | Type: []string  | Type: []int64 | Type: []bool | Type: []time.Time               | Type: []*time.Time              | Type: []time.Time               | Type: []json.RawMessage |
-//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+
-//  | Issue #1       | firstUser      | ACME Corp            | grafana/grafana | 1             | false        | 2020-08-25 16:21:56 +0000 +0000 | null                            | 2020-08-25 16:21:56 +0000 +0000 | ["bug","help wanted"]   |
-//  | Issue #2       | secondUser     | ACME Corp            | grafana/grafana | 2             | true         | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 22:21:56 +0000 +0000 | 2020-08-25 22:21:56 +0000 +0000 | ["enhancement"]         |
-//  | Issue #3       | firstUser      | ACME Corp            | grafana/grafana | 3             | false        | 2020-08-25 16:21:56 +0000 +0000 | null                            | 2020-08-25 16:21:56 +0000 +0000 | []                      |
-//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+
+//  Dimensions: 11 Fields by 3 Rows
+//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+----------------------------+
+//  | Name: title    | Name: author   | Name: author_company | Name: repo      | Name: number  | Name: closed | Name: created_at                | Name: closed_at                 | Name: updated_at                | Name: labels            | Name: assignees            |
+//  | Labels:        | Labels:        | Labels:              | Labels:         | Labels:       | Labels:      | Labels:                         | Labels:                         | Labels:                         | Labels:                 | Labels:                    |
+//  | Type: []string | Type: []string | Type: []string       | Type: []string  | Type: []int64 | Type: []bool | Type: []time.Time               | Type: []*time.Time              | Type: []time.Time               | Type: []json.RawMessage | Type: []json.RawMessage    |
+//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+----------------------------+
+//  | Issue #1       | firstUser      | ACME Corp            | grafana/grafana | 1             | false        | 2020-08-25 16:21:56 +0000 +0000 | null                            | 2020-08-25 16:21:56 +0000 +0000 | ["bug","help wanted"]   | ["firstUser","secondUser"] |
+//  | Issue #2       | secondUser     | ACME Corp            | grafana/grafana | 2             | true         | 2020-08-25 16:21:56 +0000 +0000 | 2020-08-25 22:21:56 +0000 +0000 | 2020-08-25 22:21:56 +0000 +0000 | ["enhancement"]         | ["firstUser"]              |
+//  | Issue #3       | firstUser      | ACME Corp            | grafana/grafana | 3             | false        | 2020-08-25 16:21:56 +0000 +0000 | null                            | 2020-08-25 16:21:56 +0000 +0000 | []                      | []                         |
+//  +----------------+----------------+----------------------+-----------------+---------------+--------------+---------------------------------+---------------------------------+---------------------------------+-------------------------+----------------------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -92,6 +92,13 @@
             "typeInfo": {
               "frame": "json.RawMessage"
             }
+          },
+          {
+            "name": "assignees",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage"
+            }
           }
         ]
       },
@@ -149,6 +156,16 @@
             ],
             [
               "enhancement"
+            ],
+            []
+          ],
+          [
+            [
+              "firstUser",
+              "secondUser"
+            ],
+            [
+              "firstUser"
             ],
             []
           ]


### PR DESCRIPTION
Return a new column in the issues query: `Assignees`. This change allows users to see who is assigned to each GitHub issue directly in their Grafana dashboards and queries.

**_BEFORE THE CHANGE_**
<img width="2535" alt="Screenshot 2025-06-20 at 17 27 35" src="https://github.com/user-attachments/assets/63ee60c0-8c97-469b-b9de-0fc593419fec" />

**_AFTER THE CHANGE_**
<img width="2537" alt="Screenshot 2025-06-20 at 17 26 47" src="https://github.com/user-attachments/assets/a02d41a2-dde7-47a7-8159-887293ebe5e5" />



