### PR TITLE
chore: add alternate "rate limit exceeded" error handling

### DIFF
--- a/pkg/github/client/errorsourcehandling.go
+++ b/pkg/github/client/errorsourcehandling.go
@@ -20,6 +20,7 @@ var (
 		"Resource protected by organization SAML enforcement",
 		"Resource not accessible by personal access token",
 		"API rate limit exceeded",
+		"API rate limit already exceeded",
 		"Resource not accessible by integration", // issue with incorrectly set permissions for token/app
 	}
 )

--- a/pkg/github/client/errorsourcehandling_test.go
+++ b/pkg/github/client/errorsourcehandling_test.go
@@ -82,6 +82,12 @@ func TestAddErrorSourceToError(t *testing.T) {
 			expected: backend.DownstreamError(errors.New("API rate limit exceeded for ID 1")),
 		},
 		{
+			name:     "limit exceeded error message",
+			err:      errors.New("API rate limit already exceeded for ID 2"),
+			resp:     nil,
+			expected: backend.DownstreamError(errors.New("API rate limit already exceeded for ID 2")),
+		},
+		{
 			name:     "permission error message",
 			err:      errors.New("Resource not accessible by integration"),
 			resp:     nil,

--- a/pkg/github/testdata/stargazers.golden.jsonc
+++ b/pkg/github/testdata/stargazers.golden.jsonc
@@ -9,15 +9,15 @@
 //  }
 //  Name: stargazers
 //  Dimensions: 8 Fields by 3 Rows
-//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
-//  | Name: starred_at              | Name: star_count | Name: id       | Name: login    | Name: git_name | Name: company  | Name: email                | Name: url                                   |
-//  | Labels:                       | Labels:          | Labels:        | Labels:        | Labels:        | Labels:        | Labels:                    | Labels:                                     |
-//  | Type: []time.Time             | Type: []int64    | Type: []string | Type: []string | Type: []string | Type: []string | Type: []string             | Type: []string                              |
-//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
-//  | 2023-01-14 10:21:41 +0000 GMT | 3                | NEVER          | gonna          | Run            | Around         | and_desert_you@example.org | https://www.youtube.com/watch?v=dQw4w9WgXcQ |
-//  | 2023-01-14 10:23:41 +0000 GMT | 2                | NEVER          | gonna          | Let            | You            | down@example.org           |                                             |
-//  | 2023-01-14 10:25:41 +0000 GMT | 1                | NEVER          | gonna          | Give           | You            | up@example.org             |                                             |
-//  +-------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  +---------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  | Name: starred_at                | Name: star_count | Name: id       | Name: login    | Name: git_name | Name: company  | Name: email                | Name: url                                   |
+//  | Labels:                         | Labels:          | Labels:        | Labels:        | Labels:        | Labels:        | Labels:                    | Labels:                                     |
+//  | Type: []time.Time               | Type: []int64    | Type: []string | Type: []string | Type: []string | Type: []string | Type: []string             | Type: []string                              |
+//  +---------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
+//  | 2023-01-14 10:21:41 +0000 +0000 | 3                | NEVER          | gonna          | Run            | Around         | and_desert_you@example.org | https://www.youtube.com/watch?v=dQw4w9WgXcQ |
+//  | 2023-01-14 10:23:41 +0000 +0000 | 2                | NEVER          | gonna          | Let            | You            | down@example.org           |                                             |
+//  | 2023-01-14 10:25:41 +0000 +0000 | 1                | NEVER          | gonna          | Give           | You            | up@example.org             |                                             |
+//  +---------------------------------+------------------+----------------+----------------+----------------+----------------+----------------------------+---------------------------------------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟


### PR DESCRIPTION
The existing handling with the message "API rate limit exceeded..." catches some errors, but we're now seeing errors like "API rate limit already exceeded...", which are causing SLO warnings.