### PR TITLE
remove <base target="_blank"> from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<base target="_blank">
-
 # Grafana GitHub data source
 
 The GitHub data source plugin for Grafana lets you to query the GitHub API in Grafana so you can visualize your GitHub repositories and projects.


### PR DESCRIPTION
Removing `<base target="_blank">` as it's causing issue on plugin catalog page https://github.com/grafana/github-datasource/pull/461#issuecomment-3195651172