### PR TITLE
update github workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,21 +7,20 @@ on:
     types:
       - opened
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   add-to-project:
+    permissions:
+      contents: read
+      id-token: write
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
       - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-oss-big-tent
       - name: Add to project
-        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # main
+        uses: actions/add-to-project@8b5d8dd2895c251002b427e4688a6115b5ed2f09 # main
         with:
-          project-url: https://github.com/orgs/grafana/projects/457
+          project-url: https://github.com/orgs/grafana/projects/1085 # Grafana Data Source Plugins Squad 🐴
           github-token: ${{ steps.get-github-token.outputs.token }}

--- a/.github/workflows/update-create-plugin.yml
+++ b/.github/workflows/update-create-plugin.yml
@@ -5,17 +5,16 @@ on:
   schedule:
     - cron: '0 0 1 * *' # run once a month on the 1st day
 
-permissions:
-  contents: write
-  id-token: write # Needed for create-github-app-token
-  pull-requests: write
-
 jobs:
   release:
+    permissions:
+      contents: write
+      id-token: write # Needed for create-github-app-token
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-oss-big-tent
       - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b #create-plugin-update/v2.0.1


### PR DESCRIPTION
Updates the repos github workflows:

-  `add-to-project` to use latest versions for get-github-token and add-to-project parent. Also restricts permissions on content and id-token and updates project ID (`457` -> `1085`)

- `update-create-plugin` to use latest version for get-github-token