### PR TITLE
feat: add Branches query type for listing repository branches

### DIFF
--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -31,6 +31,7 @@ This document describes the query types and response fields available in the Git
 
 Select a query type from the **Query Type** drop-down in the query editor:
 
+- [**Branches**](#branches): List branches for a repository, with optional name filtering.
 - [**Code scanning**](#code-scanning): Query code scanning alerts for a repository or organization.
 - [**Commit files**](#commit-files): List files changed in a specific commit.
 - [**Commits**](#commits): Retrieve a list of commits for a branch or ref within a repository, including commit message, author, and timestamp.
@@ -771,6 +772,41 @@ Show all stargazers for the `grafana/grafana` repository within the current time
 | company | Company name of the GitHub user who starred the repository |
 | email | Email address of the GitHub user who starred the repository |
 | url | URL to the GitHub profile for the user who starred the repository |
+
+### Branches
+
+List branches for a repository.
+
+#### Query options
+
+| Name | Description | Required |
+|------|-------------|----------|
+| Owner | The GitHub user or organization that owns the repository | Yes |
+| Repository | The name of the repository | Yes |
+| Filter | Filter branches by name prefix (e.g. `release/` matches all `release/*` branches). Leave empty to list all branches. | No |
+
+##### Sample queries
+
+Show all branches for the `grafana/grafana` repository:
+
+- Owner: `grafana`
+- Repository: `grafana`
+
+Show only release branches:
+
+- Owner: `grafana`
+- Repository: `grafana`
+- Filter: `release/`
+
+#### Response
+
+| Name | Description |
+|------|-------------|
+| name | Name of the branch |
+| commit_sha | SHA of the latest commit on the branch |
+| author | Name of the user who authored the latest commit |
+| author_login | GitHub handle of the commit author |
+| commit_date | Date of the latest commit: YYYY-MM-DD HH:MM:SS |
 
 ### Tags
 

--- a/pkg/github/branches.go
+++ b/pkg/github/branches.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/shurcooL/githubv4"
+)
+
+type branchDTO struct {
+	Name        string
+	CommitSHA   string
+	AuthorName  string
+	AuthorLogin string
+	CommitDate  time.Time
+}
+
+// Branches is a list of GitHub branches
+type Branches []branchDTO
+
+// Frames converts the list of branches to a Grafana DataFrame
+func (b Branches) Frames() data.Frames {
+	frame := data.NewFrame(
+		"branches",
+		data.NewField("name", nil, []string{}),
+		data.NewField("commit_sha", nil, []string{}),
+		data.NewField("author", nil, []string{}),
+		data.NewField("author_login", nil, []string{}),
+		data.NewField("commit_date", nil, []time.Time{}),
+	)
+
+	for _, v := range b {
+		frame.AppendRow(
+			v.Name,
+			v.CommitSHA,
+			v.AuthorName,
+			v.AuthorLogin,
+			v.CommitDate,
+		)
+	}
+
+	return data.Frames{frame}
+}
+
+// QueryListBranches is the GraphQL query for listing GitHub branches in a repository
+//
+//	{
+//	  repository(name: "grafana", owner: "grafana") {
+//	    refs(refPrefix: "refs/heads/", first: 100, after: $cursor, query: $query) {
+//	      nodes {
+//	        name
+//	        target {
+//	          ... on Commit {
+//	            oid
+//	            author {
+//	              date
+//	              user {
+//	                login
+//	                name
+//	              }
+//	            }
+//	          }
+//	        }
+//	      }
+//	      pageInfo {
+//	        hasNextPage
+//	        endCursor
+//	      }
+//	    }
+//	  }
+//	}
+type QueryListBranches struct {
+	Repository struct {
+		Refs struct {
+			Nodes []struct {
+				Name   string
+				Target struct {
+					Commit commit `graphql:"... on Commit"`
+				}
+			}
+			PageInfo models.PageInfo
+		} `graphql:"refs(refPrefix: \"refs/heads/\", first: 100, after: $cursor, query: $query)"`
+	} `graphql:"repository(name: $name, owner: $owner)"`
+}
+
+// GetAllBranches retrieves every branch from a repository, filtered by the optional query string
+func GetAllBranches(ctx context.Context, client models.Client, opts models.ListBranchesOptions) (Branches, error) {
+	var (
+		variables = map[string]interface{}{
+			"cursor": (*githubv4.String)(nil),
+			"owner":  githubv4.String(opts.Owner),
+			"name":   githubv4.String(opts.Repository),
+			"query":  githubv4.String(opts.Query),
+		}
+
+		branches = []branchDTO{}
+	)
+
+	for {
+		q := &QueryListBranches{}
+		if err := client.Query(ctx, q, variables); err != nil {
+			return nil, err
+		}
+
+		for _, node := range q.Repository.Refs.Nodes {
+			branches = append(branches, branchDTO{
+				Name:        node.Name,
+				CommitSHA:   node.Target.Commit.OID,
+				AuthorName:  node.Target.Commit.Author.User.Name,
+				AuthorLogin: node.Target.Commit.Author.User.Login,
+				CommitDate:  node.Target.Commit.Author.Date.Time,
+			})
+		}
+
+		if !q.Repository.Refs.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = q.Repository.Refs.PageInfo.EndCursor
+	}
+
+	return branches, nil
+}

--- a/pkg/github/branches_handler.go
+++ b/pkg/github/branches_handler.go
@@ -1,0 +1,24 @@
+package github
+
+import (
+	"context"
+
+	"github.com/grafana/github-datasource/pkg/dfutil"
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func (s *QueryHandler) handleBranchesQuery(ctx context.Context, q backend.DataQuery) backend.DataResponse {
+	query := &models.BranchesQuery{}
+	if err := UnmarshalQuery(q.JSON, query); err != nil {
+		return *err
+	}
+	return dfutil.FrameResponseWithError(s.Datasource.HandleBranchesQuery(ctx, query, q))
+}
+
+// HandleBranches handles the plugin query for github branches
+func (s *QueryHandler) HandleBranches(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return &backend.QueryDataResponse{
+		Responses: processQueries(ctx, req, s.handleBranchesQuery),
+	}, nil
+}

--- a/pkg/github/branches_test.go
+++ b/pkg/github/branches_test.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/github-datasource/pkg/models"
+	"github.com/grafana/github-datasource/pkg/testutil"
+)
+
+func TestListBranches(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		opts = models.ListBranchesOptions{
+			Repository: "grafana",
+			Owner:      "grafana",
+			Query:      "release/",
+		}
+	)
+
+	testVariables := testutil.GetTestVariablesFunction("query", "name", "owner", "cursor")
+
+	client := testutil.NewTestClient(t,
+		testVariables,
+		testutil.GetTestQueryFunction(&QueryListBranches{}),
+	)
+
+	_, err := GetAllBranches(ctx, client, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/github/datasource.go
+++ b/pkg/github/datasource.go
@@ -81,6 +81,16 @@ func (d *Datasource) HandleTagsQuery(ctx context.Context, query *models.TagsQuer
 	return GetTagsInRange(ctx, d.client, opt, req.TimeRange.From, req.TimeRange.To)
 }
 
+// HandleBranchesQuery is the query handler for listing GitHub Branches
+func (d *Datasource) HandleBranchesQuery(ctx context.Context, query *models.BranchesQuery, req backend.DataQuery) (dfutil.Framer, error) {
+	opt := models.ListBranchesOptions{
+		Repository: query.Repository,
+		Owner:      query.Owner,
+		Query:      query.Options.Query,
+	}
+	return GetAllBranches(ctx, d.client, opt)
+}
+
 // HandleReleasesQuery is the query handler for listing GitHub Releases
 func (d *Datasource) HandleReleasesQuery(ctx context.Context, query *models.ReleasesQuery, req backend.DataQuery) (dfutil.Framer, error) {
 	opt := models.ListReleasesOptions{

--- a/pkg/github/query_handler.go
+++ b/pkg/github/query_handler.go
@@ -54,6 +54,7 @@ func GetQueryHandlers(s *QueryHandler) *datasource.QueryTypeMux {
 	register(models.QueryTypePullRequestReviews, s.HandlePullRequestReviews)
 	register(models.QueryTypeReleases, s.HandleReleases)
 	register(models.QueryTypeTags, s.HandleTags)
+	register(models.QueryTypeBranches, s.HandleBranches)
 	register(models.QueryTypePackages, s.HandlePackages)
 	register(models.QueryTypeMilestones, s.HandleMilestones)
 	register(models.QueryTypeRepositories, s.HandleRepositories)

--- a/pkg/models/branches.go
+++ b/pkg/models/branches.go
@@ -1,0 +1,13 @@
+package models
+
+// ListBranchesOptions are the available options when listing branches
+type ListBranchesOptions struct {
+	// Repository is the name of the repository being queried (ex: grafana)
+	Repository string `json:"repository"`
+
+	// Owner is the owner of the repository (ex: grafana)
+	Owner string `json:"owner"`
+
+	// Query filters branches by name prefix/substring (ex: release/)
+	Query string `json:"query"`
+}

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -53,6 +53,8 @@ const (
 	QueryTypeCommitFiles QueryType = "Commit_Files"
 	// QueryTypePullRequestFiles is used when querying files changed in a specific pull request
 	QueryTypePullRequestFiles QueryType = "Pull_Request_Files"
+	// QueryTypeBranches is used when querying branches in a GitHub repository
+	QueryTypeBranches QueryType = "Branches"
 )
 
 // Query refers to the structure of a query built using the QueryEditor.
@@ -184,4 +186,10 @@ type CommitFilesQuery struct {
 type PullRequestFilesQuery struct {
 	Query
 	Options PullRequestFilesOptions `json:"options"`
+}
+
+// BranchesQuery is used when querying for branches in a GitHub repository
+type BranchesQuery struct {
+	Query
+	Options ListBranchesOptions `json:"options"`
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const QueryTypes = [
   'Issues',
   'Contributors',
   'Tags',
+  'Branches',
   'Releases',
   'Pull_Requests',
   'Pull_Request_Reviews',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -52,6 +52,13 @@ export type TagsOptions = Options & {}
 type TagsQuery = BaseQuery<'Tags', TagsOptions>
 //#endregion
 
+//#region Branches Query
+export type BranchesOptions = Options & {
+  query?: string;
+}
+type BranchesQuery = BaseQuery<'Branches', BranchesOptions>
+//#endregion
+
 //#region Releases Query
 export type ReleasesOptions = Options & {}
 type ReleasesQuery = BaseQuery<'Releases', ReleasesOptions>
@@ -194,7 +201,8 @@ export type GitHubQuery =
   Workflow_RunsQuery |
   Workflow_UsageQuery |
   WorkflowsQuery |
-  DeploymentsQuery
+  DeploymentsQuery |
+  BranchesQuery
 
 export type GitHubVariableQuery = { key?: string; field?: string; } & GitHubQuery
 

--- a/src/views/QueryEditor.tsx
+++ b/src/views/QueryEditor.tsx
@@ -24,6 +24,7 @@ import { QueryEditorWorkflowUsage } from './QueryEditorWorkflowUsage';
 import { QueryEditorWorkflowRuns } from './QueryEditorWorkflowRuns';
 import { QueryEditorCodeScanning } from './QueryEditorCodeScanning';
 import { QueryEditorDeployments } from './QueryEditorDeployments';
+import { QueryEditorBranches } from './QueryEditorBranches';
 
 import { DefaultQueryType, QueryTypes } from '../constants';
 
@@ -42,6 +43,11 @@ const queryEditors: Record<QueryType, { component: (props: Props, onChange: (val
   ['Organizations']: { component: () => <></> },
   ['ProjectItems']: { component: () => <></> },
   ['Tags']: { component: () => <></> },
+  ['Branches']: {
+    component: (props: Props, onChange: (val: any) => void) => (
+      <QueryEditorBranches {...(props.query.options || {})} onChange={onChange} />
+    ),
+  },
   ['Releases']: { component: () => <></> },
   ['Vulnerabilities']: { component: () => <></> },
   ['Stargazers']: { component: () => <></> },

--- a/src/views/QueryEditorBranches.test.tsx
+++ b/src/views/QueryEditorBranches.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { QueryEditorBranches } from './QueryEditorBranches';
+import { render, screen } from '@testing-library/react';
+
+describe('QueryEditorBranches', () => {
+  it('renders a Filter input field', () => {
+    const props = { onChange: jest.fn() };
+    render(<QueryEditorBranches {...props} />);
+    expect(screen.getByPlaceholderText('release/')).toBeInTheDocument();
+  });
+
+  it('shows existing query value', () => {
+    const onChange = jest.fn();
+    render(<QueryEditorBranches query="release/" onChange={onChange} />);
+    const input = screen.getByPlaceholderText('release/');
+    expect(input).toHaveValue('release/');
+  });
+});

--- a/src/views/QueryEditorBranches.test.tsx
+++ b/src/views/QueryEditorBranches.test.tsx
@@ -4,15 +4,13 @@ import { render, screen } from '@testing-library/react';
 
 describe('QueryEditorBranches', () => {
   it('renders a Filter input field', () => {
-    const props = { onChange: jest.fn() };
-    render(<QueryEditorBranches {...props} />);
-    expect(screen.getByPlaceholderText('release/')).toBeInTheDocument();
+    render(<QueryEditorBranches onChange={jest.fn()} />);
+    expect(screen.getByText('Filter')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
   it('shows existing query value', () => {
-    const onChange = jest.fn();
-    render(<QueryEditorBranches query="release/" onChange={onChange} />);
-    const input = screen.getByPlaceholderText('release/');
-    expect(input).toHaveValue('release/');
+    render(<QueryEditorBranches query="release/" onChange={jest.fn()} />);
+    expect(screen.getByRole('textbox')).toHaveValue('release/');
   });
 });

--- a/src/views/QueryEditorBranches.tsx
+++ b/src/views/QueryEditorBranches.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Input } from '@grafana/ui';
+import { EditorField, EditorRow } from '@grafana/plugin-ui';
+import { BranchesOptions } from '../types/query';
+import { LeftColumnWidth, RightColumnWidth } from './QueryEditor';
+
+interface Props extends BranchesOptions {
+  onChange: (value: BranchesOptions) => void;
+}
+
+export const QueryEditorBranches = ({ query = '', onChange }: Props) => {
+  const [filter, setFilter] = useState<string>(query);
+
+  return (
+    <EditorRow>
+      <EditorField
+        label="Filter"
+        tooltip="Filter branches by name prefix (e.g. release/ matches all release/* branches). Leave empty to list all branches."
+        width={LeftColumnWidth}
+      >
+        <Input
+          aria-label="Branch filter"
+          placeholder="release/"
+          value={filter}
+          onChange={(e) => setFilter(e.currentTarget.value)}
+          onBlur={() => onChange({ query: filter })}
+          width={RightColumnWidth}
+        />
+      </EditorField>
+    </EditorRow>
+  );
+};

--- a/src/views/QueryEditorBranches.tsx
+++ b/src/views/QueryEditorBranches.tsx
@@ -20,7 +20,6 @@ export const QueryEditorBranches = ({ query = '', onChange }: Props) => {
       >
         <Input
           aria-label="Branch filter"
-          placeholder="release/"
           value={filter}
           onChange={(e) => setFilter(e.currentTarget.value)}
           onBlur={() => onChange({ query: filter })}


### PR DESCRIPTION
## Summary

- Adds a new `Branches` query type to the GitHub datasource plugin, allowing users to list all branches of a repository
- Supports an optional **Filter** field (e.g. `release/`) that narrows results to branches whose names match the given prefix, covering the `release/*` use case
- Works as a Grafana template variable: set Field Value = `name` to use branch names as variable options in dashboards
- Related issues: https://github.com/grafana/github-datasource/issues/310, https://github.com/grafana/github-datasource/issues/94

## Implementation

Backend (Go):
- `pkg/models/branches.go` — `ListBranchesOptions` with owner, repository, and query filter
- `pkg/github/branches.go` — GraphQL query against `refs(refPrefix: "refs/heads/")` with pagination, mirrors the existing `Tags` implementation
- `pkg/github/branches_handler.go` + `datasource.go` + `query_handler.go` — handler wired into the query mux

Frontend (TypeScript/React):
- `src/views/QueryEditorBranches.tsx` — editor with an optional Filter input; tooltip explains the `release/` prefix example
- `src/types/query.ts` / `src/constants.ts` — `BranchesOptions` type and `Branches` registered in the query type list

Docs:
- `docs/sources/query-editor.md` — added `Branches` entry to the query type list and a full reference section with query options, sample queries, and response fields

## Test Plan

- [x] Go unit test passes: `go test ./pkg/github/... -run TestListBranches`
- [x] All Go tests pass: `go test ./...`
- [x] All frontend tests pass: `npm test`
- [ ] In Grafana: create a Query variable using the GitHub datasource, select **Branches**, set owner/repo — branch names appear as variable options
- [ ] Enter `release/` in the Filter field — results narrow to matching branches only
- [ ] `docs/sources/query-editor.md` contains a `### Branches` section with the Filter option documented