### PR TITLE
fix(security): bump out-of-SLO react-router to 6.30.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "webpack-virtual-modules": "0.6.2"
   },
   "resolutions": {
+    "react-router@npm:6.30.3": "6.30.4",
     "@remix-run/router": "1.23.3",
     "@openfeature/core": "1.11.0",
     "serialize-javascript": "7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11126,14 +11126,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Pin out-of-SLO transitive `react-router` 6.30.3 → 6.30.4 (CVE-2026-40181)
- Selective resolution keeps `react-router@5.3.4` untouched; `@remix-run/router` already pinned at 1.23.3
- Checks: typecheck + test:ci (21) pass