### PR TITLE
Prepare release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 2.9.0
+
+### Minor Changes
+
+🚀 Add Branches query type for listing repository branches
+
+### Patch Changes
+
+⚙️ Chore: Updated frontend & backend dependencies
+📝 Docs: Updated GitHub data source docs
+🐛 Emit null pushed_at instead of a zero date for commits
+🐛 Paginate Code Scanning alerts instead of returning only the first page
+🐛 Security: bump out-of-SLO react-router to 6.30.4
+
 ## 2.8.1
 
 ⚙️ Updating experimental schemas.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-github-datasource",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "private": true,
   "description": "Grafana data source plugin for Github",
   "repository": "github:grafana/github-datasource",


### PR DESCRIPTION
- Bump version to `2.9.0` in `package.json`
- Update `CHANGELOG.md` with changes since [v2.8.0](https://github.com/grafana/github-datasource/releases/tag/v2.8.0) (released 2026-04-02); includes unreleased 2.8.1 work already on main
- Checks: spellcheck pass; merge then run Plugins CI CD per CONTRIBUTING